### PR TITLE
5.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{ name = "David Carmichael", email = "david@uilix.com" }]
 readme = "README.md"
 license = { file = "LICENSE" }
 classifiers = ["License :: OSI Approved :: MIT License"]
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 
 dependencies = [
     "MarkupSafe >= 2.1.3",
@@ -34,14 +34,14 @@ requires = ["flit_core >=3.2,<4"]
 build-backend = "flit_core.buildapi"
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 files = ["src/pyhead"]
 show_error_codes = true
 pretty = true
 strict = true
 
 [tool.pyright]
-pythonVersion = "3.9"
+pythonVersion = "3.10"
 include = ["src/pyhead"]
 typeCheckingMode = "basic"
 

--- a/src/pyhead/__init__.py
+++ b/src/pyhead/__init__.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, TypeAlias
 
 from markupsafe import Markup
 
@@ -30,42 +30,41 @@ from .elements import (
     Verification,
 )
 
+HeadElement: TypeAlias = (
+    ApplicationName
+    | Base
+    | Charset
+    | ContentSecurityPolicy
+    | Description
+    | Favicon
+    | FormatDetection
+    | GeoPosition
+    | Google
+    | Keywords
+    | Link
+    | Meta
+    | OpenGraphWebsite
+    | Page
+    | ReferrerPolicy
+    | Robots
+    | Script
+    | SocialMediaCard
+    | Stylesheet
+    | ThemeColor
+    | Title
+    | TwitterCard
+    | Verification
+)
+
 
 class Head:
     e: dict  # Element ID: Element Class
 
     title: Optional[str] = None
 
-    _elements: list
+    _elements: list[HeadElement]
 
-    def __init__(
-        self,
-        elements_: list[
-            ApplicationName
-            | Base
-            | Charset
-            | ContentSecurityPolicy
-            | Description
-            | Favicon
-            | FormatDetection
-            | GeoPosition
-            | Google
-            | Keywords
-            | Link
-            | Meta
-            | OpenGraphWebsite
-            | Page
-            | ReferrerPolicy
-            | Robots
-            | Script
-            | SocialMediaCard
-            | Stylesheet
-            | ThemeColor
-            | Title
-            | TwitterCard
-            | Verification
-        ],
-    ) -> None:
+    def __init__(self, elements_: list[HeadElement]) -> None:
         """
         This is the main class that controls the rendering of elements.
 
@@ -80,51 +79,15 @@ class Head:
             head = Head([Page(title="My Website")])
 
         :param elements_:
-            A list of objects that can include any of the following types:
-            ApplicationName, Base, Charset, ContentSecurityPolicy, Description,
-            Favicon, FormatDetection, GeoPosition, Google, Keywords, Link, Meta,
-            OpenGraphWebsite, Page, ReferrerPolicy, Robots, Script,
-            SocialMediaCard, Stylesheet, ThemeColor, Title, TwitterCard,
-            Verification.
-        :type elements_: list[ApplicationName | Base | Charset |
-            ContentSecurityPolicy | Description | Favicon | FormatDetection |
-            GeoPosition | Google | Keywords | Link | Meta | OpenGraphWebsite |
-            Page | ReferrerPolicy | Robots | Script | SocialMediaCard |
-            Stylesheet | ThemeColor | Title | TwitterCard | Verification]
+            A list of head elements. See ``HeadElement`` for the accepted types.
+        :type elements_: list[HeadElement]
         """
         self.e = {}
 
         self._elements = elements_
         self._loop_elements(elements_)
 
-    def _loop_elements(
-        self,
-        elements_: list[
-            ApplicationName
-            | Base
-            | Charset
-            | ContentSecurityPolicy
-            | Description
-            | Favicon
-            | FormatDetection
-            | GeoPosition
-            | Google
-            | Keywords
-            | Link
-            | Meta
-            | OpenGraphWebsite
-            | Page
-            | ReferrerPolicy
-            | Robots
-            | Script
-            | SocialMediaCard
-            | Stylesheet
-            | ThemeColor
-            | Title
-            | TwitterCard
-            | Verification
-        ],
-    ) -> None:
+    def _loop_elements(self, elements_: list[HeadElement]) -> None:
         """
         A private method that loops through elements and adds them to head.e dict.
 
@@ -171,33 +134,7 @@ class Head:
         if self.e.get("title"):
             self.title = self.e["title"]._title
 
-    def extend(
-        self,
-        elements_: list[
-            ApplicationName
-            | Base
-            | Charset
-            | ContentSecurityPolicy
-            | Description
-            | Favicon
-            | FormatDetection
-            | GeoPosition
-            | Google
-            | Keywords
-            | Link
-            | Meta
-            | OpenGraphWebsite
-            | Page
-            | ReferrerPolicy
-            | Robots
-            | Script
-            | Stylesheet
-            | ThemeColor
-            | Title
-            | TwitterCard
-            | Verification
-        ],
-    ) -> "Head":
+    def extend(self, elements_: list[HeadElement]) -> "Head":
         """
         Used to extend an already initialized Head object.
 
@@ -268,31 +205,7 @@ class Head:
 
 
 class HeadClass:
-    elements: list[
-        ApplicationName
-        | Base
-        | Charset
-        | ContentSecurityPolicy
-        | Description
-        | Favicon
-        | FormatDetection
-        | GeoPosition
-        | Google
-        | Keywords
-        | Link
-        | Meta
-        | OpenGraphWebsite
-        | Page
-        | ReferrerPolicy
-        | Robots
-        | Script
-        | SocialMediaCard
-        | Stylesheet
-        | ThemeColor
-        | Title
-        | TwitterCard
-        | Verification
-    ]
+    elements: list[HeadElement]
 
     def __new__(cls):
         return Head(cls.elements)
@@ -302,6 +215,7 @@ __all__ = [
     "__version__",
     "Head",
     "HeadClass",
+    "HeadElement",
     "ApplicationName",
     "Base",
     "Charset",

--- a/src/pyhead/elements/base.py
+++ b/src/pyhead/elements/base.py
@@ -1,6 +1,6 @@
 from typing import Union
 
-from markupsafe import Markup
+from markupsafe import Markup, escape
 
 from ..protocols import CompileDelayed
 
@@ -24,7 +24,9 @@ class Base:
         return Markup(self.compile())
 
     def compile(self) -> str:
-        if isinstance(self._href, CompileDelayed):
-            return f'<base href="{self._href.compile()}">'
-        else:
-            return f'<base href="{self._href}">'
+        href = (
+            self._href.compile()
+            if isinstance(self._href, CompileDelayed)
+            else self._href
+        )
+        return f'<base href="{escape(href)}">'

--- a/src/pyhead/elements/charset.py
+++ b/src/pyhead/elements/charset.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from markupsafe import Markup
+from markupsafe import Markup, escape
 
 
 class Charset:
@@ -22,4 +22,4 @@ class Charset:
         return Markup(self.compile())
 
     def compile(self) -> str:
-        return f'<meta charset="{self._charset}">'
+        return f'<meta charset="{escape(self._charset)}">'

--- a/src/pyhead/elements/description.py
+++ b/src/pyhead/elements/description.py
@@ -1,4 +1,4 @@
-from markupsafe import Markup
+from markupsafe import Markup, escape
 
 
 class Description:
@@ -20,4 +20,4 @@ class Description:
         return Markup(self.compile())
 
     def compile(self) -> str:
-        return f'<meta name="description" content="{self._description}">'
+        return f'<meta name="description" content="{escape(self._description)}">'

--- a/src/pyhead/elements/google.py
+++ b/src/pyhead/elements/google.py
@@ -29,7 +29,9 @@ class Google:
             self._googlebot = Meta(name="googlebot", content=googlebot)
 
         if no_sitelinks_search_box:
-            self.sitelinks = Meta(name="google", content="nositelinkssearchbox")
+            self._sitelinkssearchbox = Meta(
+                name="google", content="nositelinkssearchbox"
+            )
 
         if no_translate:
             self._no_translate = Meta(name="google", content="notranslate")

--- a/src/pyhead/elements/keywords.py
+++ b/src/pyhead/elements/keywords.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from markupsafe import Markup
+from markupsafe import Markup, escape
 
 
 class Keywords:
@@ -31,4 +31,4 @@ class Keywords:
 
     def compile(self) -> str:
         join = ", ".join(self._keywords)
-        return f'<meta name="keywords" content="{join}">'
+        return f'<meta name="keywords" content="{escape(join)}">'

--- a/src/pyhead/elements/link.py
+++ b/src/pyhead/elements/link.py
@@ -1,21 +1,21 @@
 from typing import Optional, Union, Literal
 
-from markupsafe import Markup
+from markupsafe import Markup, escape
 
 from ..protocols import CompileDelayed
 
 
 class Link:
     unique: bool = False
-    key: str = None
+    key: Optional[str] = None
 
     _rel: str
-    _href: Union[str, CompileDelayed]
-    _sizes: str
-    _type: str
-    _hreflang: str
+    _href: Optional[Union[str, CompileDelayed]]
+    _sizes: Optional[str]
+    _type: Optional[str]
+    _hreflang: Optional[str]
     _crossorigin: Optional[Literal["anonymous", "use-credentials"]]
-    _id: str
+    _id: Optional[str]
 
     def __init__(
         self,
@@ -51,26 +51,29 @@ class Link:
         __items = []
 
         if self._rel:
-            __items.append(f'rel="{self._rel}"')
+            __items.append(f'rel="{escape(self._rel)}"')
 
         if self._href:
             if _repr:
                 __items.append(f'href="{self._href}"')
             else:
-                __items.append(
-                    f'href="{self._href.compile() if isinstance(self._href, CompileDelayed) else self._href}"'
+                href = (
+                    self._href.compile()
+                    if isinstance(self._href, CompileDelayed)
+                    else self._href
                 )
+                __items.append(f'href="{escape(href)}"')
 
         if self._sizes:
-            __items.append(f'sizes="{self._sizes}"')
+            __items.append(f'sizes="{escape(self._sizes)}"')
 
         if self._type:
-            __items.append(f'type="{self._type}"')
+            __items.append(f'type="{escape(self._type)}"')
 
         if self._hreflang:
-            __items.append(f'hreflang="{self._hreflang}"')
+            __items.append(f'hreflang="{escape(self._hreflang)}"')
 
         if self._crossorigin:
-            __items.append(f'crossorigin="{self._crossorigin}"')
+            __items.append(f'crossorigin="{escape(self._crossorigin)}"')
 
         return f"<link {' '.join(__items)}>"

--- a/src/pyhead/elements/meta.py
+++ b/src/pyhead/elements/meta.py
@@ -1,19 +1,19 @@
 from typing import Optional, Union
 
-from markupsafe import Markup
+from markupsafe import Markup, escape
 
 from ..protocols import CompileDelayed
 
 
 class Meta:
     unique: bool = False
-    key: str = None
+    key: Optional[str] = None
 
-    _name: str
-    _http_equiv: str
-    _property: str
-    _content: str
-    _id: str
+    _name: Optional[str]
+    _http_equiv: Optional[str]
+    _property: Optional[str]
+    _content: Optional[Union[str, CompileDelayed]]
+    _id: Optional[str]
 
     def __init__(
         self,
@@ -48,21 +48,21 @@ class Meta:
         __items = []
 
         if self._name:
-            __items.append(f'name="{self._name}"')
+            __items.append(f'name="{escape(self._name)}"')
 
         if self._http_equiv:
-            __items.append(f'http-equiv="{self._http_equiv}"')
+            __items.append(f'http-equiv="{escape(self._http_equiv)}"')
 
         if self._property:
-            __items.append(f'property="{self._property}"')
+            __items.append(f'property="{escape(self._property)}"')
 
         if self._content:
             if isinstance(self._content, CompileDelayed):
-                __items.append(f'content="{self._content.compile()}"')
+                __items.append(f'content="{escape(self._content.compile())}"')
             else:
-                __items.append(f'content="{self._content}"')
+                __items.append(f'content="{escape(self._content)}"')
 
         if self._id:
-            __items.append(f'id="{self._id}"')
+            __items.append(f'id="{escape(self._id)}"')
 
         return f"<meta {' '.join(__items)}>"

--- a/src/pyhead/elements/page.py
+++ b/src/pyhead/elements/page.py
@@ -36,7 +36,7 @@ class Page:
         if keywords is not None:
             if isinstance(keywords, str):
                 self.e["keywords"] = Keywords(from_string=keywords)
-            if isinstance(keywords, list):
+            elif isinstance(keywords, list):
                 self.e["keywords"] = Keywords(from_list=keywords)
 
         if subject is not None:

--- a/src/pyhead/elements/script.py
+++ b/src/pyhead/elements/script.py
@@ -1,23 +1,23 @@
 from typing import Optional, Union
 
-from markupsafe import Markup
+from markupsafe import Markup, escape
 
 from ..protocols import CompileDelayed
 
 
 class Script:
     unique: bool = False
-    key: str = None
+    key: Optional[str] = None
 
-    _src: str
-    _type: str
+    _src: Union[str, CompileDelayed]
+    _type: Optional[str]
     _async: bool
     _defer: bool
-    _crossorigin: str
-    _integrity: str
+    _crossorigin: Optional[str]
+    _integrity: Optional[str]
     _nomodule: bool
-    _referrerpolicy: str
-    _id: str
+    _referrerpolicy: Optional[str]
+    _id: Optional[str]
 
     def __init__(
         self,
@@ -57,22 +57,27 @@ class Script:
         __items = []
 
         if self._src:
-            __items.append(f'src="{self._src}"')
+            src = (
+                self._src.compile()
+                if isinstance(self._src, CompileDelayed)
+                else self._src
+            )
+            __items.append(f'src="{escape(src)}"')
         if self._type:
-            __items.append(f'type="{self._type}"')
+            __items.append(f'type="{escape(self._type)}"')
         if self._async:
             __items.append(f'async="{str(self._async).lower()}"')
         if self._defer:
             __items.append(f'defer="{str(self._defer).lower()}"')
         if self._crossorigin:
-            __items.append(f'crossorigin="{self._crossorigin}"')
+            __items.append(f'crossorigin="{escape(self._crossorigin)}"')
         if self._integrity:
-            __items.append(f'integrity="{self._integrity}"')
+            __items.append(f'integrity="{escape(self._integrity)}"')
         if self._nomodule:
             __items.append(f'nomodule="{str(self._nomodule).lower()}"')
         if self._referrerpolicy:
-            __items.append(f'referrerpolicy="{self._referrerpolicy}"')
+            __items.append(f'referrerpolicy="{escape(self._referrerpolicy)}"')
         if self._id:
-            __items.append(f'id="{self._id}"')
+            __items.append(f'id="{escape(self._id)}"')
 
         return f"<script {' '.join(__items)}></script>"

--- a/src/pyhead/elements/title.py
+++ b/src/pyhead/elements/title.py
@@ -1,9 +1,8 @@
-from markupsafe import Markup
+from markupsafe import Markup, escape
 
 
 class Title:
     unique: bool = True
-    disabled: bool = False
     key: str = "title"
 
     _title: str
@@ -24,4 +23,4 @@ class Title:
         return Markup(f"{self.compile()}")
 
     def compile(self) -> str:
-        return f"<title>{self._title}</title>"
+        return f"<title>{escape(self._title)}</title>"

--- a/src/pyhead/flask/__init__.py
+++ b/src/pyhead/flask/__init__.py
@@ -1,13 +1,5 @@
 from typing import Any
 
-try:
-    from flask import url_for
-except ImportError:
-    raise ImportError(
-        "You are trying to use something from the Flask library, "
-        "but Flask is not installed. Install Flask with 'pip install flask'."
-    )
-
 
 class FlaskUrlFor:
     """
@@ -45,6 +37,14 @@ class FlaskUrlFor:
         self.values = values
 
     def compile(self) -> str:
+        try:
+            from flask import url_for
+        except ImportError as e:
+            raise ImportError(
+                "You are trying to use FlaskUrlFor, but Flask is not installed. "
+                "Install Flask with 'pip install flask'."
+            ) from e
+
         return url_for(
             self.endpoint,
             _anchor=self._anchor,


### PR DESCRIPTION
- Fixed `Google(no_sitelinks_search_box=True)` silently doing nothing — the meta tag was assigned to the wrong attribute and never emitted.
- Fixed `Script(src=FlaskUrlFor(...))` rendering a repr string instead of resolving the URL. `Script.compile()` now calls `.compile()` on `CompileDelayed` sources like `Meta`, `Link`, and `Base` already did.
- Added HTML escaping at every interpolation site in `Title`, `Meta`, `Link`, `Script`, `Description`, `Keywords`, `Charset`, and `Base`. User-supplied strings containing `<`, `>`, `"`, or `&` no longer break the page or allow injection.
- Removed dead `Title.disabled` attribute that was never honoured by `Head.compile()`.
- Changed `Page` keyword-branching from `if`/`if` to `if`/`elif` for clearer intent.
- Fixed `key: str = None` → `Optional[str]` on `Meta`, `Link`, and `Script`, and tightened other nullable annotations.
- Added a `HeadElement` type alias in `pyhead/__init__.py` so the long element union is defined once instead of repeated in three places. Exported via `__all__`.
- Bumped `requires-python` from `>=3.7` to `>=3.10` to match the PEP 604 unions and PEP 585 generics already used in the code. mypy and pyright `python_version` bumped to `3.10` to match.
- Deferred `from flask import url_for` in `pyhead/flask/__init__.py` from module scope into `FlaskUrlFor.compile()`, so importing `FlaskUrlFor` no longer raises `ImportError` when Flask isn't installed.
