### PR TITLE
5.4.0a2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,4 @@ cython_debug/
 
 # Project exclude paths
 /dist/
+/CHANGES.md

--- a/src/pyhead/__init__.py
+++ b/src/pyhead/__init__.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import Optional, TypeAlias
 
 from markupsafe import Markup
@@ -95,7 +96,7 @@ class Head:
         :return: None
         :rtype: None
         """
-        for index, element in enumerate(elements_):
+        for element in elements_:
             if isinstance(element, Page):
                 if self.e.get("title"):
                     del self.e["title"]
@@ -128,8 +129,13 @@ class Head:
                 continue
 
             key = has_key(element)
-
-            self.e[str(key if key else index)] = element
+            if key:
+                self.e[str(key)] = element
+            else:
+                fallback = str(len(self.e))
+                while fallback in self.e:
+                    fallback = str(int(fallback) + 1)
+                self.e[fallback] = element
 
         if self.e.get("title"):
             self.title = self.e["title"]._title
@@ -160,16 +166,15 @@ class Head:
 
     def copy(self) -> "Head":
         """
-        Creates and returns a copy of the current object.
+        Creates and returns a deep copy of the current Head.
 
-        The method generates a new instance of the same type by creating a deep
-        copy of its underlying attributes.
+        Element instances are duplicated so that mutations on the copy do not
+        affect the original.
 
-        :return: A new instance of the same type as the original object with
-                 copied data.
+        :return: A new Head whose elements are independent of the original's.
         :rtype: Head
         """
-        return Head(self._elements)
+        return Head(deepcopy(self._elements))
 
     def compile(self, skip_title: bool = False) -> Markup:
         """

--- a/src/pyhead/_cli.py
+++ b/src/pyhead/_cli.py
@@ -6,12 +6,6 @@ import click
 
 from .elements import Link, Favicon
 
-try:
-    from favicons import Favicons
-except ImportError:
-    print("Please install the favicons library. Run 'pip install favicons'.")
-    exit(1)
-
 
 def check_source(source: Path) -> Optional[Path]:
     supported_file_ext = [".png", ".jpg", ".jpeg", ".gif", ".svg", ".tiff"]
@@ -19,6 +13,12 @@ def check_source(source: Path) -> Optional[Path]:
         return source
     else:
         return None
+
+
+def _join_href(prefix: str, filename: str) -> str:
+    if not prefix:
+        return filename
+    return f"{prefix if prefix.endswith('/') else prefix + '/'}{filename}"
 
 
 py_file = """\
@@ -84,6 +84,14 @@ def generate_favicons(
 
     Paths are relative to the current working directory.
     """
+    try:
+        from favicons import Favicons
+    except ImportError as e:
+        raise click.ClickException(
+            "The 'favicons' library is required for this command. "
+            "Install it with 'pip install favicons'."
+        ) from e
+
     cwd = Path.cwd()
     source = cwd / source
     output_dir = cwd / output
@@ -93,12 +101,11 @@ def generate_favicons(
     object_code = output_dir / "favicon-delete_me_after_use.py"
 
     if raw_favicon is None:
-        print(
-            "Source file either does not exist, or is the incorrect format of [png, jpg, jpeg, gif, svg, tiff]"
+        raise click.ClickException(
+            "Source file either does not exist, or is the incorrect format of "
+            "[png, jpg, jpeg, gif, svg, tiff]"
         )
-        exit(1)
 
-    # Clear the output directory
     if not output_dir.exists():
         output_dir.mkdir()
 
@@ -110,13 +117,8 @@ def generate_favicons(
                 favicon_tags,
                 icon,
                 Link(
-                    **{
-                        k: v
-                        for k, v in meta.items()
-                        if k not in ["generated_filename", "content"]
-                    },
-                    href=f"{href_prefix if href_prefix.endswith('/') else href_prefix + '/'}"
-                    f"{meta['generated_filename']}",
+                    **{k: v for k, v in meta.items() if k != "generated_filename"},
+                    href=_join_href(href_prefix, meta["generated_filename"]),
                 ),
             )
 
@@ -126,8 +128,7 @@ def generate_favicons(
                 dedent(
                     py_file.format(
                         **{
-                            k: f"{href_prefix if href_prefix.endswith('/') else href_prefix + '/'}"
-                            f"{v['generated_filename']}"
+                            k: _join_href(href_prefix, v["generated_filename"])
                             for k, v in favicon_tags._icon_reference.items()
                         }
                     )

--- a/src/pyhead/elements/application_name.py
+++ b/src/pyhead/elements/application_name.py
@@ -4,7 +4,6 @@ from .meta import Meta
 
 
 class ApplicationName:
-    unique: bool = True
     key: str = "application_name"
 
     _content: str

--- a/src/pyhead/elements/base.py
+++ b/src/pyhead/elements/base.py
@@ -6,7 +6,6 @@ from ..protocols import CompileDelayed
 
 
 class Base:
-    unique: bool = True
     key: str = "base"
 
     _href: Union[str, CompileDelayed]

--- a/src/pyhead/elements/charset.py
+++ b/src/pyhead/elements/charset.py
@@ -4,7 +4,6 @@ from markupsafe import Markup, escape
 
 
 class Charset:
-    unique: bool = True
     key: str = "charset"
 
     _charset: Optional[str]

--- a/src/pyhead/elements/content_security_policy.py
+++ b/src/pyhead/elements/content_security_policy.py
@@ -4,7 +4,6 @@ from .meta import Meta
 
 
 class ContentSecurityPolicy:
-    unique: bool = True
     key: str = "content_security_policy"
 
     _content: str

--- a/src/pyhead/elements/description.py
+++ b/src/pyhead/elements/description.py
@@ -2,7 +2,6 @@ from markupsafe import Markup, escape
 
 
 class Description:
-    unique: bool = True
     key: str = "description"
 
     _description: str

--- a/src/pyhead/elements/favicon.py
+++ b/src/pyhead/elements/favicon.py
@@ -7,7 +7,6 @@ from ..protocols import CompileDelayed
 
 
 class Favicon:
-    unique: bool = True
     key: str = "favicon"
 
     _ico_icon_href: Optional[Link] = None
@@ -137,22 +136,22 @@ class Favicon:
         },
         "_png_mstile_70_href": {
             "rel": "msapplication-square70x70logo",
-            "content": "image/png",
+            "type_": "image/png",
             "generated_filename": "mstile-70x70.png",
         },
         "_png_mstile_270_href": {
             "rel": "msapplication-square270x270logo",
-            "content": "image/png",
+            "type_": "image/png",
             "generated_filename": "mstile-270x270.png",
         },
         "_png_mstile_310x150_href": {
             "rel": "msapplication-wide310x150logo",
-            "content": "image/png",
+            "type_": "image/png",
             "generated_filename": "mstile-310x150.png",
         },
         "_png_mstile_310_href": {
             "rel": "msapplication-wide310x150logo",
-            "content": "image/png",
+            "type_": "image/png",
             "generated_filename": "mstile-310x150.png",
         },
     }
@@ -214,7 +213,7 @@ class Favicon:
                         **{
                             k: v
                             for k, v in self._icon_reference[name].items()
-                            if k not in ["generated_filename", "content"]
+                            if k != "generated_filename"
                         },
                         href=value,
                     ),
@@ -223,7 +222,7 @@ class Favicon:
     def __repr__(self) -> str:
         attrs = " ".join(
             [
-                str(getattr(self, o_link)._ta_href)
+                f'href="{getattr(self, o_link)._href}"'
                 for o_link in self._icon_reference
                 if getattr(self, o_link) is not None
             ]

--- a/src/pyhead/elements/format_detection.py
+++ b/src/pyhead/elements/format_detection.py
@@ -4,7 +4,6 @@ from .meta import Meta
 
 
 class FormatDetection:
-    unique: bool = True
     key: str = "format_detection"
 
     _telephone: bool

--- a/src/pyhead/elements/geo_position.py
+++ b/src/pyhead/elements/geo_position.py
@@ -6,7 +6,6 @@ from .meta import Meta
 
 
 class GeoPosition:
-    unique: bool = True
     key: str = "geo_position"
 
     _icbm: Optional[Meta] = None

--- a/src/pyhead/elements/google.py
+++ b/src/pyhead/elements/google.py
@@ -6,7 +6,6 @@ from .meta import Meta
 
 
 class Google:
-    unique: bool = True
     key: str = "google"
 
     _googlebot: Optional[Meta] = None

--- a/src/pyhead/elements/keywords.py
+++ b/src/pyhead/elements/keywords.py
@@ -4,7 +4,6 @@ from markupsafe import Markup, escape
 
 
 class Keywords:
-    unique: bool = True
     key: str = "keywords"
 
     _keywords: list[str]

--- a/src/pyhead/elements/link.py
+++ b/src/pyhead/elements/link.py
@@ -6,7 +6,6 @@ from ..protocols import CompileDelayed
 
 
 class Link:
-    unique: bool = False
     key: Optional[str] = None
 
     _rel: str
@@ -75,5 +74,8 @@ class Link:
 
         if self._crossorigin:
             __items.append(f'crossorigin="{escape(self._crossorigin)}"')
+
+        if self._id:
+            __items.append(f'id="{escape(self._id)}"')
 
         return f"<link {' '.join(__items)}>"

--- a/src/pyhead/elements/meta.py
+++ b/src/pyhead/elements/meta.py
@@ -6,7 +6,6 @@ from ..protocols import CompileDelayed
 
 
 class Meta:
-    unique: bool = False
     key: Optional[str] = None
 
     _name: Optional[str]

--- a/src/pyhead/elements/open_graph_website.py
+++ b/src/pyhead/elements/open_graph_website.py
@@ -7,14 +7,13 @@ from ..protocols import CompileDelayed
 
 
 class OpenGraphWebsite:
-    unique: bool = True
     key: str = "open_graph_website"
 
     _type: Meta
     _locale: Optional[Meta] = None
     _title: Optional[Meta] = None
-    _url: Optional[Union[str, CompileDelayed]] = None
-    _image: Optional[Union[str, CompileDelayed]] = None
+    _url: Optional[Meta] = None
+    _image: Optional[Meta] = None
     _image_alt: Optional[Meta] = None
     _description: Optional[Meta] = None
     _site_name: Optional[Meta] = None

--- a/src/pyhead/elements/page.py
+++ b/src/pyhead/elements/page.py
@@ -25,8 +25,8 @@ class Page:
         viewport: str = "width=device-width, initial-scale=1",
     ) -> None:
         self.e = {
-            "title": Title(title),
             "charset": Charset(charset),
+            "title": Title(title),
             "viewport": Meta(name="viewport", content=viewport),
         }
 

--- a/src/pyhead/elements/referrer_policy.py
+++ b/src/pyhead/elements/referrer_policy.py
@@ -4,7 +4,6 @@ from .meta import Meta
 
 
 class ReferrerPolicy:
-    unique: bool = True
     key: str = "referrer_policy"
 
     _content: str

--- a/src/pyhead/elements/robots.py
+++ b/src/pyhead/elements/robots.py
@@ -4,7 +4,6 @@ from .meta import Meta
 
 
 class Robots:
-    unique: bool = True
     key: str = "robots"
 
     _content: str

--- a/src/pyhead/elements/script.py
+++ b/src/pyhead/elements/script.py
@@ -6,7 +6,6 @@ from ..protocols import CompileDelayed
 
 
 class Script:
-    unique: bool = False
     key: Optional[str] = None
 
     _src: Union[str, CompileDelayed]

--- a/src/pyhead/elements/social_media_card.py
+++ b/src/pyhead/elements/social_media_card.py
@@ -1,6 +1,5 @@
 from typing import Optional, Literal, Union
 
-from .meta import Meta
 from .open_graph_website import OpenGraphWebsite
 from .twitter_card import TwitterCard
 from ..protocols import CompileDelayed
@@ -8,18 +7,6 @@ from ..protocols import CompileDelayed
 
 class SocialMediaCard:
     e: dict
-
-    _type: Meta
-    _locale: Optional[Meta] = None
-    _site_name: Optional[Meta] = None
-    _card: Meta
-    _site_account: Optional[Meta] = None
-    _creator_account: Optional[Meta] = None
-    _title: Optional[Meta] = None
-    _description: Optional[Meta] = None
-    _image: Optional[Union[str, CompileDelayed]] = None
-    _image_alt: Optional[Meta] = None
-    _url: Optional[Union[str, CompileDelayed]] = None
 
     def __init__(
         self,

--- a/src/pyhead/elements/stylesheet.py
+++ b/src/pyhead/elements/stylesheet.py
@@ -7,8 +7,7 @@ from ..protocols import CompileDelayed
 
 
 class Stylesheet:
-    unique: bool = False
-    key: str = None
+    key: Optional[str] = None
 
     _href: Union[str, CompileDelayed]
     _id: Optional[str]
@@ -16,8 +15,6 @@ class Stylesheet:
     def __init__(
         self, href: Union[str, CompileDelayed], id_: Optional[str] = None
     ) -> None:
-        self.unique = False
-
         self._href = href
         self._id = id_
 

--- a/src/pyhead/elements/theme_color.py
+++ b/src/pyhead/elements/theme_color.py
@@ -4,7 +4,6 @@ from .meta import Meta
 
 
 class ThemeColor:
-    unique: bool = True
     key: str = "theme_color"
 
     _content: str

--- a/src/pyhead/elements/title.py
+++ b/src/pyhead/elements/title.py
@@ -2,7 +2,6 @@ from markupsafe import Markup, escape
 
 
 class Title:
-    unique: bool = True
     key: str = "title"
 
     _title: str

--- a/src/pyhead/elements/twitter_card.py
+++ b/src/pyhead/elements/twitter_card.py
@@ -7,7 +7,6 @@ from ..protocols import CompileDelayed
 
 
 class TwitterCard:
-    unique: bool = True
     key: str = "twitter_card"
 
     _card: Meta

--- a/src/pyhead/elements/verification.py
+++ b/src/pyhead/elements/verification.py
@@ -6,7 +6,6 @@ from .meta import Meta
 
 
 class Verification:
-    unique: bool = True
     key: str = "verification"
 
     _google: Optional[Meta] = None


### PR DESCRIPTION
- Fixed `Google(no_sitelinks_search_box=True)` silently doing nothing — the meta tag was assigned to the wrong attribute and never emitted.
- Fixed `Script(src=FlaskUrlFor(...))` rendering a repr string instead of resolving the URL. `Script.compile()` now calls `.compile()` on `CompileDelayed` sources like `Meta`, `Link`, and `Base` already did.
- Added HTML escaping at every interpolation site in `Title`, `Meta`, `Link`, `Script`, `Description`, `Keywords`, `Charset`, and `Base`. User-supplied strings containing `<`, `>`, `"`, or `&` no longer break the page or allow injection.
- Fixed `Favicon.__repr__` crashing with `AttributeError` whenever any icon was set — it referenced `_ta_href` on `Link`, which doesn't exist; corrected to `_href`.
- Fixed `Favicon` mstile entries using the wrong dict key (`content` instead of `type_`), so `type="image/png"` was silently dropped from the generated `<link>` tags for Microsoft tile icons.
- `Link` now renders `id="..."` in its HTML output when `id_` is supplied. Previously the parameter was accepted (and used for dedup keying) but never emitted, so `Stylesheet(id_=...)` also lost its id.
- Fixed `Head.extend(...)` silently overwriting previously-added elements. Extended elements with no explicit `key` used to re-start their index from `0`, colliding with existing entries; indexed fallback keys now skip occupied slots.
- `Head.copy()` is now a true deep copy (via `copy.deepcopy`). Previously it reused the same element instances, so mutating the copy also mutated the original, contradicting the docstring.
- Fixed `OpenGraphWebsite._url` and `_image` class annotations — they were typed as `Optional[Union[str, CompileDelayed]]` but runtime values are always `Meta` instances.