### PR TITLE
6.0.0a

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ def create_app():
                 google="1234567890",
                 yandex="1234567890",
                 bing="1234567890",
-                alexa="1234567890",
             ),
             e.GeoPosition(
                 icbm="55.86013028402754, -4.252019430273945",
@@ -153,43 +152,43 @@ Results in:
 ```html
 <html lang="en">
 <head>
-<title>Hello World</title>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1" >
-<meta name="description" content="This is a test" >
+<title>Hello World</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="This is a test">
 <meta name="keywords" content="test,  hello,  world">
-<meta name="subject" content="Hello World" >
-<meta name="rating" content="General" >
+<meta name="subject" content="Hello World">
+<meta name="rating" content="General">
 <base href="http://127.0.0.1:5000">
-<meta name="robots" content="index, follow" >
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'" >
-<meta name="referrer" content="no-referrer" >
-<meta name="googlebot" content="index, follow" >
-<meta name="google" content="notranslate" >
-<meta name="google-site-verification" content="1234567890" >
-<meta name="yandex-verification" content="1234567890" >
-<meta name="msvalidate.01" content="1234567890" >
-<meta name="alexaVerifyID" content="1234567890" >
-<meta name="ICBM" content="55.86013028402754, -4.252019430273945" >
-<meta name="geo.position" content="55.86013028402754;-4.252019430273945" >
-<meta name="geo.region" content="en_GB" >
-<meta name="geo.placename" content="Duke of Wellington" >
-<meta name="twitter:card" content="summary_large_image" >
-<meta name="twitter:site" content="@example" >
-<meta name="twitter:creator" content="@example" >
-<meta name="twitter:title" content="Example" >
-<meta name="twitter:description" content="Example" >
-<meta name="twitter:image" content="https://example.com/image.png" >
-<meta name="twitter:image:alt" content="Example" >
-<meta name="twitter:url" content="https://example.com" >
-<meta property="og:type" content="website" >
-<meta property="og:locale" content="en_US" >
-<meta property="og:site_name" content="Example" >
-<meta property="og:title" content="Example" >
-<meta property="og:description" content="Example" >
-<meta property="og:image" content="https://example.com/image.png" >
-<meta property="og:image:alt" content="Example" >
-<meta property="og:url" content="https://example.com" >
+<meta name="robots" content="index, follow">
+<meta http-equiv="Content-Security-Policy" content="default-src &#39;self&#39;">
+<meta name="referrer" content="no-referrer">
+<meta name="googlebot" content="index, follow">
+<meta name="google" content="nositelinkssearchbox">
+<meta name="google" content="notranslate">
+<meta name="google-site-verification" content="1234567890">
+<meta name="yandex-verification" content="1234567890">
+<meta name="msvalidate.01" content="1234567890">
+<meta name="ICBM" content="55.86013028402754, -4.252019430273945">
+<meta name="geo.position" content="55.86013028402754;-4.252019430273945">
+<meta name="geo.region" content="en_GB">
+<meta name="geo.placename" content="Duke of Wellington">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@example">
+<meta name="twitter:creator" content="@example">
+<meta name="twitter:title" content="Example">
+<meta name="twitter:description" content="Example">
+<meta name="twitter:image" content="https://example.com/image.png">
+<meta name="twitter:image:alt" content="Example">
+<meta name="twitter:url" content="https://example.com">
+<meta property="og:type" content="website">
+<meta property="og:locale" content="en_US">
+<meta property="og:site_name" content="Example">
+<meta property="og:title" content="Example">
+<meta property="og:description" content="Example">
+<meta property="og:image" content="https://example.com/image.png">
+<meta property="og:image:alt" content="Example">
+<meta property="og:url" content="https://example.com">
 <link rel="icon" href="/static/favicons/favicon.ico" sizes="16x16 32x32" type="image/x-icon">
 <link rel="icon" href="/static/favicons/favicon-16x16.png" sizes="16x16" type="image/png">
 <link rel="icon" href="/static/favicons/favicon-32x32.png" sizes="32x32" type="image/png">
@@ -207,10 +206,10 @@ Results in:
 <link rel="apple-touch-icon" href="/static/favicons/apple-touch-icon-152x152.png" sizes="152x152" type="image/png">
 <link rel="apple-touch-icon" href="/static/favicons/apple-touch-icon-167x167.png" sizes="167x167" type="image/png">
 <link rel="apple-touch-icon" href="/static/favicons/apple-touch-icon-180x180.png" sizes="180x180" type="image/png">
-<link rel="msapplication-square70x70logo" href="/static/favicons/mstile-70x70.png">
-<link rel="msapplication-square270x270logo" href="/static/favicons/mstile-270x270.png">
-<link rel="msapplication-wide310x150logo" href="/static/favicons/mstile-310x150.png">
-<link rel="msapplication-wide310x150logo" href="/static/favicons/mstile-310x150.png">
+<link rel="msapplication-square70x70logo" href="/static/favicons/mstile-70x70.png" type="image/png">
+<link rel="msapplication-square270x270logo" href="/static/favicons/mstile-270x270.png" type="image/png">
+<link rel="msapplication-wide310x150logo" href="/static/favicons/mstile-310x150.png" type="image/png">
+<link rel="msapplication-wide310x150logo" href="/static/favicons/mstile-310x150.png" type="image/png">
 <link rel="canonical" href="https://example.com">
 <link rel="canonical" href="https://example.co.uk">
 <script src="/static/example.js" type="module"></script>
@@ -221,7 +220,6 @@ Results in:
 <p>Right-Click view source</p>
 </body>
 </html>
-
 ```
 
 ## Usage Examples

--- a/README.md
+++ b/README.md
@@ -5,18 +5,29 @@
 
 The Python HTML `<head>` filler.
 
-`pip install pyhead`
+```bash
+pip install pyhead              # core only
+pip install "pyhead[flask]"     # core + Flask helpers
+pip install "pyhead[django]"    # core + Django helpers
+```
+
+Pyhead is framework-agnostic at its core. Flask and Django are only needed if you want the deferred `url_for` / `reverse` / `static` helpers or the Django template tags.
 
 <!-- TOC -->
 * [pyhead 🐍🤯](#pyhead-)
   * [What is Pyhead?](#what-is-pyhead)
   * [Flask example](#flask-example)
+  * [Django example](#django-example)
   * [Usage Examples](#usage-examples)
     * [Route by Route](#route-by-route)
     * [Copy and Extend](#copy-and-extend)
     * [Class Defined](#class-defined)
     * [Flask Specific](#flask-specific)
       * [`url_for` -> `FlaskUrlFor`](#url_for---flaskurlfor)
+    * [Django Specific](#django-specific)
+      * [`reverse` -> `DjangoUrlFor`](#reverse---djangourlfor)
+      * [`static` -> `DjangoStatic`](#static---djangostatic)
+      * [Template tags: `{% head %}` and `{% head_title %}`](#template-tags--head--and--head_title-)
   * [CLI Commands](#cli-commands)
     * [Generating favicons](#generating-favicons)
 <!-- TOC -->
@@ -112,39 +123,41 @@ def create_app():
     return app
 ```
 
-`index.html`:
+`index.html` — full render (pyhead writes the `<head>` wrapper itself):
 
 ```html
 <!DOCTYPE html>
 <html lang="en">
-<head>
-<title>{{ head.title }}</title>
-{{ head.compile(skip_title=True) }}
-</head>
-
+{{ head.compile() }}
 <body>
-{% block content %}
-
-{% endblock %}
+{% block content %}{% endblock %}
 </body>
 </html>
 ```
 
-or
+or — split render, where you write the `<head>` wrapper and let pyhead fill it:
 
 ```html
 <!DOCTYPE html>
 <html lang="en">
 <head>
-{{ head.compile() }}
+    {{ head.compile(render_head_tag=False) }}
 </head>
 
 <body>
-{% block content %}
-
-{% endblock %}
+{% block content %}{% endblock %}
 </body>
 </html>
+```
+
+If you also want the `<title>` separate from the rest of the head, pass both flags
+and render the title element yourself (it's available at `head.e["title"]`):
+
+```html
+<head>
+    <title>{{ head.e["title"] }}</title>
+    {{ head.compile(render_head_tag=False, render_title_tag=False) }}
+</head>
 ```
 
 Results in:
@@ -219,6 +232,82 @@ Results in:
 <h1>Flask App</h1>
 <p>Right-Click view source</p>
 </body>
+</html>
+```
+
+## Django example
+
+Register `pyhead.django` in `INSTALLED_APPS` so its template tag library is discoverable:
+
+```python
+# settings.py
+INSTALLED_APPS = [
+    # ...
+    "django.contrib.staticfiles",
+    "pyhead.django",
+]
+```
+
+Build a `Head` in your view, pass it to the template as context:
+
+```python
+# views.py
+from django.shortcuts import render
+
+from pyhead import Head
+from pyhead import elements as e
+from pyhead.django import DjangoStatic, DjangoUrlFor
+
+
+def index(request):
+    head = Head([
+        e.Page(
+            title="Hello World",
+            description="This is a test",
+            keywords="test, hello, world",
+        ),
+        e.Link(rel="canonical", href=DjangoUrlFor("index")),
+        e.Stylesheet(DjangoStatic("main.css")),
+        e.Script(type_="module", src=DjangoStatic("example.js")),
+    ])
+    return render(request, "index.html", {"head": head})
+```
+
+`index.html` — render the full head via the template tag:
+
+```html
+{% load pyhead %}
+<!DOCTYPE html>
+<html lang="en">
+{% head head %}
+<body>
+    <h1>Django App</h1>
+</body>
+</html>
+```
+
+Or skip the tag library entirely — `Head` implements `__html__`, so Django's
+auto-escape will render it as safe HTML:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+{{ head }}
+<body>...</body>
+</html>
+```
+
+Split render — author your own `<head>` wrapper and place the `<title>` first:
+
+```html
+{% load pyhead %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    {% head_title head %}
+    {% head head render_head_tag=False render_title_tag=False %}
+</head>
+<body>...</body>
 </html>
 ```
 
@@ -355,6 +444,57 @@ def my_cool_page():
     )
     return render_template("my_cool_page.html", head=head)
 ```
+
+### Django Specific
+
+Requires `pip install "pyhead[django]"` and `"pyhead.django"` in `INSTALLED_APPS`.
+
+#### `reverse` -> `DjangoUrlFor`
+
+`DjangoUrlFor` defers Django's `reverse()` until the `Head` is compiled, so it
+runs with the current URL configuration at request time. It accepts the same
+positional / keyword arguments as `reverse`.
+
+```python
+from pyhead import Head, elements as e
+from pyhead.django import DjangoUrlFor
+
+head = Head([
+    e.Link(rel="canonical", href=DjangoUrlFor("home")),
+    e.Link(rel="alternate", href=DjangoUrlFor("article", pk=42)),
+])
+```
+
+#### `static` -> `DjangoStatic`
+
+`DjangoStatic` defers `django.templatetags.static.static()` until compile time,
+so `STATIC_URL` and any staticfiles storage (e.g. `ManifestStaticFilesStorage`)
+are honoured.
+
+```python
+from pyhead import Head, elements as e
+from pyhead.django import DjangoStatic
+
+head = Head([
+    e.Stylesheet(DjangoStatic("main.css")),
+    e.Script(type_="module", src=DjangoStatic("example.js")),
+    e.Favicon(ico_icon_href=DjangoStatic("favicons/favicon.ico")),
+])
+```
+
+#### Template tags: `{% head %}` and `{% head_title %}`
+
+`pyhead.django` ships a template tag library. Load it with `{% load pyhead %}`.
+
+| Tag | What it renders |
+| --- | --- |
+| `{% head head %}` | The full `<head>...</head>` block, including `<title>`. |
+| `{% head head render_head_tag=False %}` | The inner elements only — you author the `<head>` wrapper. |
+| `{% head head render_head_tag=False render_title_tag=False %}` | Inner elements minus `<title>` — pair with `{% head_title head %}`. |
+| `{% head_title head %}` | Just the `<title>` tag. |
+
+`Head` also implements `__html__`, so `{{ head }}` works without `|safe` and
+without loading the tag library — handy for simple pages.
 
 ## CLI Commands
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -26,7 +26,6 @@ head = Head(
             google="1234567890",
             yandex="1234567890",
             bing="1234567890",
-            alexa="1234567890",
         ),
         e.GeoPosition(
             icbm="55.86013028402754, -4.252019430273945",
@@ -98,7 +97,6 @@ class StandardHeadClass(HeadClass):
             google="1234567890",
             yandex="1234567890",
             bing="1234567890",
-            alexa="1234567890",
         ),
         e.GeoPosition(
             icbm="55.86013028402754, -4.252019430273945",

--- a/app/templates/extends.html
+++ b/app/templates/extends.html
@@ -1,10 +1,8 @@
 <!DOCTYPE html>
 
 <html lang="en">
-<head>
-<title>{{ head.title }}</title>
-{{ head.compile(skip_title=True) }}
-</head>
+
+{{ head.compile() }}
 
 <body>
 {% block content %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,14 +13,20 @@ dependencies = [
     "click >= 8.1.7",
 ]
 
+[project.optional-dependencies]
+flask = ["flask>=3.0"]
+django = ["django>=4.2"]
+
 [dependency-groups]
 dev = [
     "flask==3.1.3",
+    "django>=4.2",
     "flit>=3.9.0",
     "mypy>=1.4.1",
     "pre-commit>=2.21.0",
     "pyright>=1.1.403",
     "pytest>=8.0",
+    "pytest-django>=4.8",
     "ruff>=0.12.4",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dev = [
     "mypy>=1.4.1",
     "pre-commit>=2.21.0",
     "pyright>=1.1.403",
+    "pytest>=8.0",
     "ruff>=0.12.4",
 ]
 

--- a/src/pyhead/__init__.py
+++ b/src/pyhead/__init__.py
@@ -4,7 +4,6 @@ from typing import Optional, TypeAlias
 from markupsafe import Markup
 
 from .__version__ import __version__
-from ._helpers import has_key
 from .elements import (
     ApplicationName,
     Base,
@@ -128,7 +127,7 @@ class Head:
                     self.e[key] = value
                 continue
 
-            key = has_key(element)
+            key = getattr(element, "key", None)
             if key:
                 self.e[str(key)] = element
             else:
@@ -161,6 +160,7 @@ class Head:
         :return: The extended Head object.
         :rtype: Head
         """
+        self._elements = [*self._elements, *elements_]
         self._loop_elements(elements_)
         return self
 
@@ -175,6 +175,63 @@ class Head:
         :rtype: Head
         """
         return Head(deepcopy(self._elements))
+
+    def copy_extend(self, elements_: list[HeadElement]) -> "Head":
+        """
+        Used to copy and extend an already initialized Head object.
+
+        .. highlight:: python
+        .. code-block:: python
+
+            from pyhead import Head
+            from pyhead.elements import Page, Description
+
+            head = Head([Page(title="My Website")])
+
+            head = head.copy_extend([Description("This is my website.")])
+
+        :param elements_:
+        :return: The copied and extended Head object.
+        :rtype: Head
+        """
+        self._elements = [*self._elements, *elements_]
+        return Head(deepcopy(self._elements))
+
+    def cp(self) -> "Head":
+        """
+        Shortcut for copy.
+
+        Creates and returns a deep copy of the current Head.
+
+        Element instances are duplicated so that mutations on the copy do not
+        affect the original.
+
+        :return: A new Head whose elements are independent of the original's.
+        :rtype: Head
+        """
+        return self.copy()
+
+    def cpe(self, elements_: list[HeadElement]) -> "Head":
+        """
+        Shortcut for copy_extend.
+
+        Used to copy and extend an already initialized Head object.
+
+        .. highlight:: python
+        .. code-block:: python
+
+            from pyhead import Head
+            from pyhead.elements import Page, Description
+
+            head = Head([Page(title="My Website")])
+
+            head = head.cpe([Description("This is my website.")])
+
+        :param elements_:
+        :return: The copied and extended Head object.
+        :rtype: Head
+        """
+        return self.copy_extend(elements_)
 
     def compile(self, skip_title: bool = False) -> Markup:
         """
@@ -213,6 +270,16 @@ class HeadClass:
     elements: list[HeadElement]
 
     def __new__(cls):
+        if cls is HeadClass:
+            raise TypeError(
+                "HeadClass is meant to be subclassed. "
+                "Define a subclass with `elements = [...]` and instantiate that."
+            )
+        if not hasattr(cls, "elements"):
+            raise TypeError(
+                f"{cls.__name__} must define an `elements` class attribute "
+                f"(a list of head elements)."
+            )
         return Head(cls.elements)
 
 

--- a/src/pyhead/__init__.py
+++ b/src/pyhead/__init__.py
@@ -276,6 +276,12 @@ class Head:
 
         return Markup("\n".join(render))
 
+    def __str__(self) -> Markup:
+        return self.compile()
+
+    def __html__(self) -> Markup:
+        return self.compile()
+
 
 class HeadClass:
     elements: list[HeadElement]

--- a/src/pyhead/__init__.py
+++ b/src/pyhead/__init__.py
@@ -60,7 +60,8 @@ HeadElement: TypeAlias = (
 class Head:
     e: dict  # Element ID: Element Class
 
-    title: Optional[str] = None
+    render_head_tag: bool = True
+    render_title_tag: Optional[str] = None
 
     _elements: list[HeadElement]
 
@@ -137,7 +138,7 @@ class Head:
                 self.e[fallback] = element
 
         if self.e.get("title"):
-            self.title = self.e["title"]._title
+            self.render_title_tag = self.e["title"]._title
 
     def extend(self, elements_: list[HeadElement]) -> "Head":
         """
@@ -233,35 +234,45 @@ class Head:
         """
         return self.copy_extend(elements_)
 
-    def compile(self, skip_title: bool = False) -> Markup:
+    def compile(
+        self, render_head_tag: bool = True, render_title_tag: bool = True
+    ) -> Markup:
         """
         Used to compile the elements in head.e dict.
 
         .. code-block::
 
-            <head>
-                {{ head.compile() }}
-            </head>
+            <html>
+            {{ head.compile() }}
+            <body>
+            ...
+            </body>
+            </html>
 
-        If you prefer to have the title rendered separately, you can use the skip_title parameter.
+        If you prefer to have the head and the title tag rendered separately,
+        you can use the render_head_tag and render_title_tag parameters.
 
         .. code-block::
 
             <head>
                 <title>{{ head.title }}</title>
-                {{ head.compile(skip_title=True) }}
+                {{ head.compile(render_head_tag = False, render_title_tag = False) }}
             </head>
 
-        :param skip_title:
+        :param render_head_tag: If False, the head tag will not be rendered.
+        :param render_title_tag: If False, the title tag will not be rendered.
         :return:
         """
-        render = []
+        render = ["<head>" if render_head_tag else ""]
 
         for key, element in self.e.items():
-            if key == "title" and skip_title:
+            if key == "title" and not render_title_tag:
                 continue
 
             render.append(str(element))
+
+        if render_head_tag:
+            render.append("</head>")
 
         return Markup("\n".join(render))
 

--- a/src/pyhead/_base.py
+++ b/src/pyhead/_base.py
@@ -1,0 +1,28 @@
+from typing import Optional
+
+from markupsafe import Markup
+
+
+class BaseElement:
+    """
+    Shared behaviour for simple (leaf) head elements.
+
+    Subclasses must implement ``compile()`` returning a string of HTML. The
+    mixin provides the boilerplate ``__str__`` and ``__call__`` wrappers that
+    every element needs — both return a ``Markup`` of the compiled output so
+    the result is usable directly inside a Jinja template.
+
+    Subclasses may set a ``key`` attribute to opt into deduplication /
+    ordering inside ``Head.e``.
+    """
+
+    key: Optional[str] = None
+
+    def compile(self) -> str:
+        raise NotImplementedError
+
+    def __str__(self) -> Markup:
+        return Markup(self.compile())
+
+    def __call__(self) -> Markup:
+        return Markup(self.compile())

--- a/src/pyhead/_helpers.py
+++ b/src/pyhead/_helpers.py
@@ -1,6 +1,0 @@
-def has_key(element):
-    if hasattr(element, "key"):
-        if element.key:
-            return element.key
-
-    return None

--- a/src/pyhead/django/__init__.py
+++ b/src/pyhead/django/__init__.py
@@ -1,0 +1,91 @@
+from typing import Any
+
+
+class DjangoUrlFor:
+    """
+    Django-specific URL generation.
+
+    This will allow the use of Django's :func:`django.urls.reverse` function
+    through the same deferred-compile pattern used elsewhere in pyhead. The
+    view name is resolved when the head is compiled, which means the current
+    URL configuration is used.
+
+    Example::
+
+        from pyhead.django import DjangoUrlFor
+        from pyhead.elements import Link
+
+        Link(rel="canonical", href=DjangoUrlFor("home"))
+    """
+
+    view_name: str
+
+    args: tuple[Any, ...]
+    kwargs: dict[str, Any]
+
+    _urlconf: Any | None = None
+    _current_app: str | None = None
+
+    def __init__(
+        self,
+        view_name: str,
+        *args: Any,
+        _urlconf: Any | None = None,
+        _current_app: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.view_name = view_name
+        self.args = args
+        self.kwargs = kwargs
+        self._urlconf = _urlconf
+        self._current_app = _current_app
+
+    def compile(self) -> str:
+        try:
+            from django.urls import reverse
+        except ImportError as e:
+            raise ImportError(
+                "You are trying to use DjangoUrlFor, but Django is not installed. "
+                "Install Django with 'pip install django'."
+            ) from e
+
+        return reverse(
+            self.view_name,
+            urlconf=self._urlconf,
+            args=self.args or None,
+            kwargs=self.kwargs or None,
+            current_app=self._current_app,
+        )
+
+
+class DjangoStatic:
+    """
+    Django-specific static file URL generation.
+
+    Wraps :func:`django.templatetags.static.static` (which honours
+    ``STATIC_URL`` and any configured staticfiles storage) behind the same
+    deferred-compile pattern. The path is resolved when the head is compiled.
+
+    Example::
+
+        from pyhead.django import DjangoStatic
+        from pyhead.elements import Stylesheet
+
+        Stylesheet(DjangoStatic("main.css"))
+    """
+
+    path: str
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+
+    def compile(self) -> str:
+        try:
+            from django.templatetags.static import static
+        except ImportError as e:
+            raise ImportError(
+                "You are trying to use DjangoStatic, but Django is not installed. "
+                "Install Django with 'pip install django'."
+            ) from e
+
+        return static(self.path)

--- a/src/pyhead/django/templatetags/pyhead.py
+++ b/src/pyhead/django/templatetags/pyhead.py
@@ -1,0 +1,59 @@
+from django import template
+from django.utils.safestring import SafeString, mark_safe
+
+from pyhead import Head
+
+register = template.Library()
+
+
+@register.simple_tag
+def head(
+    head_obj: Head,
+    *,
+    render_head_tag: bool = True,
+    render_title_tag: bool = True,
+) -> SafeString:
+    """
+    Render a pyhead ``Head`` inside a Django template.
+
+    Default usage renders the full ``<head>...</head>`` block::
+
+        {% load pyhead %}
+        <html>
+        {% head head %}
+        <body>...</body>
+        </html>
+
+    To render the ``<title>`` and the rest separately (for example when you
+    want to author the outer ``<head>`` tag yourself)::
+
+        <head>
+            {% head_title head %}
+            {% head head render_head_tag=False render_title_tag=False %}
+        </head>
+    """
+    return mark_safe(
+        head_obj.compile(
+            render_head_tag=render_head_tag,
+            render_title_tag=render_title_tag,
+        )
+    )
+
+
+@register.simple_tag
+def head_title(head_obj: Head) -> SafeString:
+    """
+    Render just the ``<title>`` tag from a pyhead ``Head``.
+
+    Usage::
+
+        {% load pyhead %}
+        <head>
+            {% head_title head %}
+            {% head head render_head_tag=False render_title_tag=False %}
+        </head>
+    """
+    title_element = head_obj.e.get("title")
+    if title_element is None:
+        return mark_safe("<title>Title Not Set</title>")
+    return mark_safe(str(title_element))

--- a/src/pyhead/elements/application_name.py
+++ b/src/pyhead/elements/application_name.py
@@ -1,9 +1,8 @@
-from markupsafe import Markup
-
+from .._base import BaseElement
 from .meta import Meta
 
 
-class ApplicationName:
+class ApplicationName(BaseElement):
     key: str = "application_name"
 
     _content: str
@@ -12,14 +11,7 @@ class ApplicationName:
         self._content = content
 
     def __repr__(self) -> str:
-        return f'<ApplicationName content="{self._content}">'
-
-    def __str__(self) -> Markup:
-        return Markup(self.compile())
-
-    def __call__(self) -> Markup:
-        return Markup(self.compile())
+        return f"ApplicationName(content={self._content!r})"
 
     def compile(self) -> str:
-        meta = Meta(name="application_name", content=self._content)
-        return str(meta)
+        return str(Meta(name="application_name", content=self._content))

--- a/src/pyhead/elements/base.py
+++ b/src/pyhead/elements/base.py
@@ -1,11 +1,12 @@
 from typing import Union
 
-from markupsafe import Markup, escape
+from markupsafe import escape
 
+from .._base import BaseElement
 from ..protocols import CompileDelayed
 
 
-class Base:
+class Base(BaseElement):
     key: str = "base"
 
     _href: Union[str, CompileDelayed]
@@ -14,13 +15,7 @@ class Base:
         self._href = href
 
     def __repr__(self) -> str:
-        return f'<Base base="{self._href}">'
-
-    def __str__(self) -> Markup:
-        return Markup(self.compile())
-
-    def __call__(self) -> Markup:
-        return Markup(self.compile())
+        return f"Base(href={self._href!r})"
 
     def compile(self) -> str:
         href = (

--- a/src/pyhead/elements/charset.py
+++ b/src/pyhead/elements/charset.py
@@ -1,24 +1,18 @@
-from typing import Optional
+from markupsafe import escape
 
-from markupsafe import Markup, escape
+from .._base import BaseElement
 
 
-class Charset:
+class Charset(BaseElement):
     key: str = "charset"
 
-    _charset: Optional[str]
+    _charset: str
 
     def __init__(self, charset: str = "utf-8") -> None:
         self._charset = charset
 
     def __repr__(self) -> str:
-        return f'<Charset charset="{self._charset}">'
-
-    def __str__(self) -> Markup:
-        return Markup(self.compile())
-
-    def __call__(self) -> Markup:
-        return Markup(self.compile())
+        return f"Charset(charset={self._charset!r})"
 
     def compile(self) -> str:
         return f'<meta charset="{escape(self._charset)}">'

--- a/src/pyhead/elements/content_security_policy.py
+++ b/src/pyhead/elements/content_security_policy.py
@@ -1,9 +1,8 @@
-from markupsafe import Markup
-
+from .._base import BaseElement
 from .meta import Meta
 
 
-class ContentSecurityPolicy:
+class ContentSecurityPolicy(BaseElement):
     key: str = "content_security_policy"
 
     _content: str
@@ -12,14 +11,7 @@ class ContentSecurityPolicy:
         self._content = content
 
     def __repr__(self) -> str:
-        return f'<ContentSecurityPolicy content="{self._content}">'
-
-    def __str__(self) -> Markup:
-        return Markup(self.compile())
-
-    def __call__(self) -> Markup:
-        return Markup(self.compile())
+        return f"ContentSecurityPolicy(content={self._content!r})"
 
     def compile(self) -> str:
-        meta = Meta(http_equiv="Content-Security-Policy", content=self._content)
-        return str(meta)
+        return str(Meta(http_equiv="Content-Security-Policy", content=self._content))

--- a/src/pyhead/elements/description.py
+++ b/src/pyhead/elements/description.py
@@ -1,7 +1,9 @@
-from markupsafe import Markup, escape
+from markupsafe import escape
+
+from .._base import BaseElement
 
 
-class Description:
+class Description(BaseElement):
     key: str = "description"
 
     _description: str
@@ -10,13 +12,7 @@ class Description:
         self._description = description
 
     def __repr__(self) -> str:
-        return f'<Description content="{self._description}">'
-
-    def __str__(self) -> Markup:
-        return Markup(self.compile())
-
-    def __call__(self) -> Markup:
-        return Markup(self.compile())
+        return f"Description(description={self._description!r})"
 
     def compile(self) -> str:
         return f'<meta name="description" content="{escape(self._description)}">'

--- a/src/pyhead/elements/favicon.py
+++ b/src/pyhead/elements/favicon.py
@@ -1,12 +1,11 @@
 from typing import Optional, Union
 
-from markupsafe import Markup
-
+from .._base import BaseElement
 from .link import Link
 from ..protocols import CompileDelayed
 
 
-class Favicon:
+class Favicon(BaseElement):
     key: str = "favicon"
 
     _ico_icon_href: Optional[Link] = None
@@ -220,27 +219,17 @@ class Favicon:
                 )
 
     def __repr__(self) -> str:
-        attrs = " ".join(
-            [
-                f'href="{getattr(self, o_link)._href}"'
-                for o_link in self._icon_reference
-                if getattr(self, o_link) is not None
-            ]
-        )
-        return f"<FavIcon {attrs}>".replace(" >", ">")
-
-    def __str__(self) -> str:
-        return Markup(self.compile())
-
-    def __call__(self) -> str:
-        return Markup(self.compile())
+        hrefs = [
+            getattr(self, o_link)._href
+            for o_link in self._icon_reference
+            if getattr(self, o_link) is not None
+        ]
+        return f"Favicon(hrefs={hrefs!r})"
 
     def compile(self) -> str:
-        _ = [
+        rendered = [
             str(getattr(self, o_link))
             for o_link in self._icon_reference
             if getattr(self, o_link) is not None
         ]
-        if _:
-            return "\n".join(_)
-        return ""
+        return "\n".join(rendered) if rendered else ""

--- a/src/pyhead/elements/format_detection.py
+++ b/src/pyhead/elements/format_detection.py
@@ -1,9 +1,8 @@
-from markupsafe import Markup
-
+from .._base import BaseElement
 from .meta import Meta
 
 
-class FormatDetection:
+class FormatDetection(BaseElement):
     key: str = "format_detection"
 
     _telephone: bool
@@ -27,13 +26,10 @@ class FormatDetection:
         self._url = url
 
     def __repr__(self) -> str:
-        return self.compile().replace("format-detection", "FormatDetection")
-
-    def __str__(self) -> Markup:
-        return Markup(self.compile())
-
-    def __call__(self) -> Markup:
-        return Markup(self.compile())
+        return (
+            f"FormatDetection(telephone={self._telephone!r}, date={self._date!r}, "
+            f"address={self._address!r}, email={self._email!r}, url={self._url!r})"
+        )
 
     def compile(self) -> str:
         __items = []

--- a/src/pyhead/elements/geo_position.py
+++ b/src/pyhead/elements/geo_position.py
@@ -1,11 +1,10 @@
 from typing import Optional
 
-from markupsafe import Markup
-
+from .._base import BaseElement
 from .meta import Meta
 
 
-class GeoPosition:
+class GeoPosition(BaseElement):
     key: str = "geo_position"
 
     _icbm: Optional[Meta] = None
@@ -41,22 +40,14 @@ class GeoPosition:
 
     def __repr__(self) -> str:
         return (
-            f"<GeoPosition icbm={self._icbm} geo_position={self._geo_position} "
-            f"geo_region={self._geo_region} geo_placename={self._geo_placename}>"
+            f"GeoPosition(icbm={self._icbm!r}, geo_position={self._geo_position!r}, "
+            f"geo_region={self._geo_region!r}, geo_placename={self._geo_placename!r})"
         )
 
-    def __str__(self) -> Markup:
-        return Markup(self.compile())
-
-    def __call__(self) -> Markup:
-        return Markup(self.compile())
-
     def compile(self) -> str:
-        _ = [
+        rendered = [
             str(getattr(self, o_tag))
             for o_tag in self._order
             if getattr(self, o_tag) is not None
         ]
-        if _:
-            return "\n".join(_)
-        return ""
+        return "\n".join(rendered) if rendered else ""

--- a/src/pyhead/elements/google.py
+++ b/src/pyhead/elements/google.py
@@ -1,11 +1,10 @@
 from typing import Optional
 
-from markupsafe import Markup
-
+from .._base import BaseElement
 from .meta import Meta
 
 
-class Google:
+class Google(BaseElement):
     key: str = "google"
 
     _googlebot: Optional[Meta] = None
@@ -37,22 +36,15 @@ class Google:
 
     def __repr__(self) -> str:
         return (
-            f"<Google googlebot={self._googlebot} sitelinkssearchbox={self._sitelinkssearchbox} "
-            f"no_translate={self._no_translate}>"
+            f"Google(googlebot={self._googlebot!r}, "
+            f"sitelinkssearchbox={self._sitelinkssearchbox!r}, "
+            f"no_translate={self._no_translate!r})"
         )
 
-    def __str__(self) -> Markup:
-        return Markup(self.compile())
-
-    def __call__(self) -> Markup:
-        return Markup(self.compile())
-
     def compile(self) -> str:
-        _ = [
+        rendered = [
             str(getattr(self, o_tag))
             for o_tag in self._order
             if getattr(self, o_tag) is not None
         ]
-        if _:
-            return "\n".join(_)
-        return ""
+        return "\n".join(rendered) if rendered else ""

--- a/src/pyhead/elements/keywords.py
+++ b/src/pyhead/elements/keywords.py
@@ -1,9 +1,11 @@
 from typing import Optional
 
-from markupsafe import Markup, escape
+from markupsafe import escape
+
+from .._base import BaseElement
 
 
-class Keywords:
+class Keywords(BaseElement):
     key: str = "keywords"
 
     _keywords: list[str]
@@ -20,13 +22,7 @@ class Keywords:
             self._keywords.extend(from_list)
 
     def __repr__(self) -> str:
-        return f'<Keywords page_keywords="{self._keywords}">'
-
-    def __str__(self) -> Markup:
-        return Markup(self.compile())
-
-    def __call__(self) -> Markup:
-        return Markup(self.compile())
+        return f"Keywords(keywords={self._keywords!r})"
 
     def compile(self) -> str:
         join = ", ".join(self._keywords)

--- a/src/pyhead/elements/link.py
+++ b/src/pyhead/elements/link.py
@@ -1,13 +1,12 @@
 from typing import Optional, Union, Literal
 
-from markupsafe import Markup, escape
+from markupsafe import escape
 
+from .._base import BaseElement
 from ..protocols import CompileDelayed
 
 
-class Link:
-    key: Optional[str] = None
-
+class Link(BaseElement):
     _rel: str
     _href: Optional[Union[str, CompileDelayed]]
     _sizes: Optional[str]
@@ -38,30 +37,31 @@ class Link:
             self.key = self._id
 
     def __repr__(self) -> str:
-        return self.compile(_repr=True).replace("link", "Link")
+        parts = [f"rel={self._rel!r}"]
+        if self._href is not None:
+            parts.append(f"href={self._href!r}")
+        if self._sizes is not None:
+            parts.append(f"sizes={self._sizes!r}")
+        if self._type is not None:
+            parts.append(f"type={self._type!r}")
+        if self._hreflang is not None:
+            parts.append(f"hreflang={self._hreflang!r}")
+        if self._crossorigin is not None:
+            parts.append(f"crossorigin={self._crossorigin!r}")
+        if self._id is not None:
+            parts.append(f"id={self._id!r}")
+        return f"Link({', '.join(parts)})"
 
-    def __str__(self) -> Markup:
-        return Markup(self.compile())
-
-    def __call__(self) -> Markup:
-        return Markup(self.compile())
-
-    def compile(self, _repr: bool = False) -> str:
-        __items = []
-
-        if self._rel:
-            __items.append(f'rel="{escape(self._rel)}"')
+    def compile(self) -> str:
+        __items = [f'rel="{escape(self._rel)}"']
 
         if self._href:
-            if _repr:
-                __items.append(f'href="{self._href}"')
-            else:
-                href = (
-                    self._href.compile()
-                    if isinstance(self._href, CompileDelayed)
-                    else self._href
-                )
-                __items.append(f'href="{escape(href)}"')
+            href = (
+                self._href.compile()
+                if isinstance(self._href, CompileDelayed)
+                else self._href
+            )
+            __items.append(f'href="{escape(href)}"')
 
         if self._sizes:
             __items.append(f'sizes="{escape(self._sizes)}"')

--- a/src/pyhead/elements/meta.py
+++ b/src/pyhead/elements/meta.py
@@ -1,13 +1,12 @@
 from typing import Optional, Union
 
-from markupsafe import Markup, escape
+from markupsafe import escape
 
+from .._base import BaseElement
 from ..protocols import CompileDelayed
 
 
-class Meta:
-    key: Optional[str] = None
-
+class Meta(BaseElement):
     _name: Optional[str]
     _http_equiv: Optional[str]
     _property: Optional[str]
@@ -22,10 +21,15 @@ class Meta:
         content: Optional[Union[str, CompileDelayed]] = None,
         id_: Optional[str] = None,
     ) -> None:
-        one_only = [name, http_equiv, property_]
-        if one_only.count(None) != 2:
+        provided = [x for x in (name, http_equiv, property_) if x is not None]
+        if len(provided) == 0:
             raise ValueError(
-                "You can only specify one of name, http_equiv, or property_."
+                "Meta requires exactly one of name, http_equiv, or property_."
+            )
+        if len(provided) > 1:
+            raise ValueError(
+                "Meta accepts only one of name, http_equiv, or property_ "
+                "(not multiple)."
             )
 
         self._name = name
@@ -35,13 +39,18 @@ class Meta:
         self._id = id_
 
     def __repr__(self) -> str:
-        return self.compile().replace("meta", "Meta")
-
-    def __str__(self) -> Markup:
-        return Markup(self.compile())
-
-    def __call__(self) -> Markup:
-        return Markup(self.compile())
+        parts = []
+        if self._name is not None:
+            parts.append(f"name={self._name!r}")
+        if self._http_equiv is not None:
+            parts.append(f"http_equiv={self._http_equiv!r}")
+        if self._property is not None:
+            parts.append(f"property={self._property!r}")
+        if self._content is not None:
+            parts.append(f"content={self._content!r}")
+        if self._id is not None:
+            parts.append(f"id={self._id!r}")
+        return f"Meta({', '.join(parts)})"
 
     def compile(self) -> str:
         __items = []

--- a/src/pyhead/elements/open_graph_website.py
+++ b/src/pyhead/elements/open_graph_website.py
@@ -1,12 +1,11 @@
 from typing import Optional, Union
 
-from markupsafe import Markup
-
+from .._base import BaseElement
 from .meta import Meta
 from ..protocols import CompileDelayed
 
 
-class OpenGraphWebsite:
+class OpenGraphWebsite(BaseElement):
     key: str = "open_graph_website"
 
     _type: Meta
@@ -62,24 +61,16 @@ class OpenGraphWebsite:
 
     def __repr__(self) -> str:
         return (
-            f"<OpenGraphWebsite type={self._type} locale={self._locale} "
-            f"title={self._title} url={self._url} image={self._image} "
-            f"image_alt={self._image_alt} description={self._description} "
-            f"site_name={self._site_name}>"
+            f"OpenGraphWebsite(type={self._type!r}, locale={self._locale!r}, "
+            f"title={self._title!r}, url={self._url!r}, image={self._image!r}, "
+            f"image_alt={self._image_alt!r}, description={self._description!r}, "
+            f"site_name={self._site_name!r})"
         )
 
-    def __str__(self) -> Markup:
-        return Markup(self.compile())
-
-    def __call__(self) -> Markup:
-        return Markup(self.compile())
-
     def compile(self) -> str:
-        _ = [
+        rendered = [
             str(getattr(self, o_tag))
             for o_tag in self._order
             if getattr(self, o_tag) is not None
         ]
-        if _:
-            return "\n".join(_)
-        return ""
+        return "\n".join(rendered) if rendered else ""

--- a/src/pyhead/elements/referrer_policy.py
+++ b/src/pyhead/elements/referrer_policy.py
@@ -1,9 +1,8 @@
-from markupsafe import Markup
-
+from .._base import BaseElement
 from .meta import Meta
 
 
-class ReferrerPolicy:
+class ReferrerPolicy(BaseElement):
     key: str = "referrer_policy"
 
     _content: str
@@ -12,14 +11,7 @@ class ReferrerPolicy:
         self._content = content
 
     def __repr__(self) -> str:
-        return f'<ReferrerPolicy content="{self._content}">'
-
-    def __str__(self) -> Markup:
-        return Markup(self.compile())
-
-    def __call__(self) -> Markup:
-        return Markup(self.compile())
+        return f"ReferrerPolicy(content={self._content!r})"
 
     def compile(self) -> str:
-        meta = Meta(name="referrer", content=self._content)
-        return str(meta)
+        return str(Meta(name="referrer", content=self._content))

--- a/src/pyhead/elements/robots.py
+++ b/src/pyhead/elements/robots.py
@@ -1,9 +1,8 @@
-from markupsafe import Markup
-
+from .._base import BaseElement
 from .meta import Meta
 
 
-class Robots:
+class Robots(BaseElement):
     key: str = "robots"
 
     _content: str
@@ -12,14 +11,7 @@ class Robots:
         self._content = content
 
     def __repr__(self) -> str:
-        return f'<Robots content="{self._content}">'
-
-    def __str__(self) -> Markup:
-        return Markup(self.compile())
-
-    def __call__(self) -> Markup:
-        return Markup(self.compile())
+        return f"Robots(content={self._content!r})"
 
     def compile(self) -> str:
-        meta = Meta(name="robots", content=self._content)
-        return str(meta)
+        return str(Meta(name="robots", content=self._content))

--- a/src/pyhead/elements/script.py
+++ b/src/pyhead/elements/script.py
@@ -1,13 +1,12 @@
 from typing import Optional, Union
 
-from markupsafe import Markup, escape
+from markupsafe import escape
 
+from .._base import BaseElement
 from ..protocols import CompileDelayed
 
 
-class Script:
-    key: Optional[str] = None
-
+class Script(BaseElement):
     _src: Union[str, CompileDelayed]
     _type: Optional[str]
     _async: bool
@@ -44,13 +43,24 @@ class Script:
             self.key = self._id
 
     def __repr__(self) -> str:
-        return self.compile().replace("script", "Script")
-
-    def __str__(self) -> Markup:
-        return Markup(self.compile())
-
-    def __call__(self) -> Markup:
-        return Markup(self.compile())
+        parts = [f"src={self._src!r}"]
+        if self._type is not None:
+            parts.append(f"type={self._type!r}")
+        if self._async:
+            parts.append(f"async_={self._async!r}")
+        if self._defer:
+            parts.append(f"defer={self._defer!r}")
+        if self._crossorigin is not None:
+            parts.append(f"crossorigin={self._crossorigin!r}")
+        if self._integrity is not None:
+            parts.append(f"integrity={self._integrity!r}")
+        if self._nomodule:
+            parts.append(f"nomodule={self._nomodule!r}")
+        if self._referrerpolicy is not None:
+            parts.append(f"referrerpolicy={self._referrerpolicy!r}")
+        if self._id is not None:
+            parts.append(f"id={self._id!r}")
+        return f"Script({', '.join(parts)})"
 
     def compile(self) -> str:
         __items = []

--- a/src/pyhead/elements/stylesheet.py
+++ b/src/pyhead/elements/stylesheet.py
@@ -1,14 +1,11 @@
 from typing import Optional, Union
 
-from markupsafe import Markup
-
+from .._base import BaseElement
 from .link import Link
 from ..protocols import CompileDelayed
 
 
-class Stylesheet:
-    key: Optional[str] = None
-
+class Stylesheet(BaseElement):
     _href: Union[str, CompileDelayed]
     _id: Optional[str]
 
@@ -22,14 +19,10 @@ class Stylesheet:
             self.key = id_
 
     def __repr__(self) -> str:
-        return f"<Stylesheet href={self._href}>"
-
-    def __str__(self) -> Markup:
-        return Markup(self.compile())
-
-    def __call__(self) -> Markup:
-        return Markup(self.compile())
+        parts = [f"href={self._href!r}"]
+        if self._id is not None:
+            parts.append(f"id={self._id!r}")
+        return f"Stylesheet({', '.join(parts)})"
 
     def compile(self) -> str:
-        stylesheet = Link(rel="stylesheet", href=self._href, id_=self._id)
-        return str(stylesheet)
+        return str(Link(rel="stylesheet", href=self._href, id_=self._id))

--- a/src/pyhead/elements/theme_color.py
+++ b/src/pyhead/elements/theme_color.py
@@ -1,9 +1,8 @@
-from markupsafe import Markup
-
+from .._base import BaseElement
 from .meta import Meta
 
 
-class ThemeColor:
+class ThemeColor(BaseElement):
     key: str = "theme_color"
 
     _content: str
@@ -12,14 +11,7 @@ class ThemeColor:
         self._content = content
 
     def __repr__(self) -> str:
-        return f'<ThemeColor content="{self._content}">'
-
-    def __str__(self) -> Markup:
-        return Markup(self.compile())
-
-    def __call__(self) -> Markup:
-        return Markup(self.compile())
+        return f"ThemeColor(content={self._content!r})"
 
     def compile(self) -> str:
-        meta = Meta(name="theme-color", content=self._content)
-        return str(meta)
+        return str(Meta(name="theme-color", content=self._content))

--- a/src/pyhead/elements/title.py
+++ b/src/pyhead/elements/title.py
@@ -1,25 +1,18 @@
-from markupsafe import Markup, escape
+from markupsafe import escape
+
+from .._base import BaseElement
 
 
-class Title:
+class Title(BaseElement):
     key: str = "title"
 
     _title: str
 
-    def __init__(
-        self,
-        title: str,
-    ) -> None:
+    def __init__(self, title: str) -> None:
         self._title = title
 
     def __repr__(self) -> str:
-        return f'<Title title="{self._title}">'
-
-    def __str__(self) -> Markup:
-        return Markup(f"{self.compile()}")
-
-    def __call__(self) -> Markup:
-        return Markup(f"{self.compile()}")
+        return f"Title(title={self._title!r})"
 
     def compile(self) -> str:
         return f"<title>{escape(self._title)}</title>"

--- a/src/pyhead/elements/twitter_card.py
+++ b/src/pyhead/elements/twitter_card.py
@@ -1,12 +1,11 @@
 from typing import Optional, Literal, Union
 
-from markupsafe import Markup
-
+from .._base import BaseElement
 from .meta import Meta
 from ..protocols import CompileDelayed
 
 
-class TwitterCard:
+class TwitterCard(BaseElement):
     key: str = "twitter_card"
 
     _card: Meta
@@ -67,24 +66,16 @@ class TwitterCard:
 
     def __repr__(self) -> str:
         return (
-            f"<TwitterCard card={self._card} site_account={self._site_account} "
-            f"creator_account={self._creator_account} title={self._title} "
-            f"description={self._description} image={self._image} "
-            f"image_alt={self._image_alt} url={self._url}>"
+            f"TwitterCard(card={self._card!r}, site_account={self._site_account!r}, "
+            f"creator_account={self._creator_account!r}, title={self._title!r}, "
+            f"description={self._description!r}, image={self._image!r}, "
+            f"image_alt={self._image_alt!r}, url={self._url!r})"
         )
 
-    def __str__(self) -> Markup:
-        return Markup(self.compile())
-
-    def __call__(self) -> Markup:
-        return Markup(self.compile())
-
     def compile(self) -> str:
-        _ = [
+        rendered = [
             str(getattr(self, o_tag))
             for o_tag in self._order
             if getattr(self, o_tag) is not None
         ]
-        if _:
-            return "\n".join(_)
-        return ""
+        return "\n".join(rendered) if rendered else ""

--- a/src/pyhead/elements/verification.py
+++ b/src/pyhead/elements/verification.py
@@ -1,17 +1,15 @@
 from typing import Optional
 
-from markupsafe import Markup
-
+from .._base import BaseElement
 from .meta import Meta
 
 
-class Verification:
+class Verification(BaseElement):
     key: str = "verification"
 
     _google: Optional[Meta] = None
     _yandex: Optional[Meta] = None
     _bing: Optional[Meta] = None
-    _alexa: Optional[Meta] = None
     _pinterest: Optional[Meta] = None
     _norton: Optional[Meta] = None
 
@@ -19,7 +17,6 @@ class Verification:
         "_google",
         "_yandex",
         "_bing",
-        "_alexa",
         "_pinterest",
         "_norton",
     ]
@@ -29,7 +26,6 @@ class Verification:
         google: Optional[str] = None,
         yandex: Optional[str] = None,
         bing: Optional[str] = None,
-        alexa: Optional[str] = None,
         pinterest: Optional[str] = None,
         norton: Optional[str] = None,
     ) -> None:
@@ -42,9 +38,6 @@ class Verification:
         if bing is not None:
             self._bing = Meta(name="msvalidate.01", content=bing)
 
-        if alexa is not None:
-            self._alexa = Meta(name="alexaVerifyID", content=alexa)
-
         if pinterest is not None:
             self._pinterest = Meta(name="p:domain_verify", content=pinterest)
 
@@ -53,23 +46,15 @@ class Verification:
 
     def __repr__(self) -> str:
         return (
-            f"<Verification google={self._google} yandex={self._yandex} "
-            f"bing={self._bing} alexa={self._alexa} pinterest={self._pinterest} "
-            f"norton={self._norton}>"
+            f"Verification(google={self._google!r}, yandex={self._yandex!r}, "
+            f"bing={self._bing!r}, pinterest={self._pinterest!r}, "
+            f"norton={self._norton!r})"
         )
 
-    def __str__(self) -> Markup:
-        return Markup(self.compile())
-
-    def __call__(self) -> Markup:
-        return Markup(self.compile())
-
     def compile(self) -> str:
-        _ = [
+        rendered = [
             str(getattr(self, o_tag))
             for o_tag in self._order
             if getattr(self, o_tag) is not None
         ]
-        if _:
-            return "\n".join(_)
-        return ""
+        return "\n".join(rendered) if rendered else ""

--- a/src/pyhead/protocols/__init__.py
+++ b/src/pyhead/protocols/__init__.py
@@ -3,4 +3,18 @@ from typing import Protocol, runtime_checkable
 
 @runtime_checkable
 class CompileDelayed(Protocol):
+    """
+    A value whose final string form is produced lazily by calling ``compile()``.
+
+    Used for things like ``FlaskUrlFor`` that need to defer resolution until
+    the surrounding ``Head`` is rendered (e.g. to acquire a request context).
+
+    Note on ``@runtime_checkable``: ``isinstance(x, CompileDelayed)`` only
+    verifies that ``x`` has a ``compile`` attribute — it does not check that
+    the attribute is callable or returns a ``str``. Callers that rely on
+    isinstance to branch should trust the duck-type contract; if you hand
+    pyhead an object with a non-callable ``compile`` attribute, rendering
+    will fail at compile time, not at dispatch time.
+    """
+
     def compile(self) -> str: ...

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -1,0 +1,139 @@
+import pytest
+
+django = pytest.importorskip("django")
+
+from django.conf import settings  # noqa: E402
+
+
+def _configure_django() -> None:
+    if settings.configured:
+        return
+    settings.configure(
+        DEBUG=False,
+        ALLOWED_HOSTS=["*"],
+        ROOT_URLCONF=__name__,
+        STATIC_URL="/static/",
+        INSTALLED_APPS=[
+            "django.contrib.staticfiles",
+            "pyhead.django",
+        ],
+        TEMPLATES=[
+            {
+                "BACKEND": "django.template.backends.django.DjangoTemplates",
+                "DIRS": [],
+                "APP_DIRS": False,
+                "OPTIONS": {
+                    "libraries": {
+                        "pyhead": "pyhead.django.templatetags.pyhead",
+                    },
+                },
+            }
+        ],
+    )
+    django.setup()
+
+
+_configure_django()
+
+
+from django.http import HttpResponse  # noqa: E402
+from django.template import Context, Template  # noqa: E402
+from django.urls import path  # noqa: E402
+
+from pyhead import Head  # noqa: E402
+from pyhead.django import DjangoStatic, DjangoUrlFor  # noqa: E402
+from pyhead.elements import Page, Script, Stylesheet  # noqa: E402
+
+
+def _home(_request):  # pragma: no cover - only registered for reverse() to find
+    return HttpResponse("ok")
+
+
+urlpatterns = [
+    path("", _home, name="home"),
+    path("article/<int:pk>/", _home, name="article"),
+]
+
+
+# ---------- DjangoUrlFor ----------
+
+
+def test_django_url_for_resolves_simple_route():
+    assert DjangoUrlFor("home").compile() == "/"
+
+
+def test_django_url_for_passes_kwargs():
+    assert DjangoUrlFor("article", pk=42).compile() == "/article/42/"
+
+
+def test_django_url_for_defers_until_compile():
+    u = DjangoUrlFor("home")
+    assert u.view_name == "home"
+    assert u.compile() == "/"
+
+
+# ---------- DjangoStatic ----------
+
+
+def test_django_static_prefixes_static_url():
+    assert DjangoStatic("main.css").compile() == "/static/main.css"
+
+
+def test_django_static_nested_path():
+    assert DjangoStatic("favicons/favicon.ico").compile() == "/static/favicons/favicon.ico"
+
+
+# ---------- Elements compose with the deferred helpers ----------
+
+
+def test_stylesheet_uses_django_static_at_compile_time():
+    out = str(Stylesheet(DjangoStatic("main.css")))
+    assert 'href="/static/main.css"' in out
+
+
+def test_script_uses_django_url_for_at_compile_time():
+    out = str(Script(src=DjangoUrlFor("home")))
+    assert 'src="/"' in out
+
+
+# ---------- Template tags ----------
+
+
+def _render(source: str, head_obj: Head) -> str:
+    return Template(source).render(Context({"head": head_obj}))
+
+
+def test_head_templatetag_renders_full_head():
+    out = _render(
+        "{% load pyhead %}{% head head %}",
+        Head([Page(title="Hi")]),
+    )
+    assert out.startswith("<head>")
+    assert out.rstrip().endswith("</head>")
+    assert "<title>Hi</title>" in out
+
+
+def test_head_templatetag_can_omit_wrapping_head_and_title():
+    out = _render(
+        "{% load pyhead %}{% head head render_head_tag=False render_title_tag=False %}",
+        Head([Page(title="Hi", description="D")]),
+    )
+    assert "<head>" not in out
+    assert "</head>" not in out
+    assert "<title>" not in out
+    assert 'name="description" content="D"' in out
+
+
+def test_head_title_templatetag_renders_only_title():
+    out = _render(
+        "{% load pyhead %}{% head_title head %}",
+        Head([Page(title="Just Title")]),
+    )
+    assert out.strip() == "<title>Just Title</title>"
+
+
+def test_head_via_str_does_not_get_autoescaped():
+    """Head.__html__ lets Django render {{ head }} without |safe."""
+    out = _render("{{ head }}", Head([Page(title="Hi")]))
+    assert "<title>Hi</title>" in out
+    assert "&lt;" not in out

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -1,0 +1,359 @@
+import pytest
+from markupsafe import Markup
+
+from pyhead.elements import (
+    ApplicationName,
+    Base,
+    Charset,
+    ContentSecurityPolicy,
+    Description,
+    Favicon,
+    FormatDetection,
+    GeoPosition,
+    Google,
+    Keywords,
+    Link,
+    Meta,
+    OpenGraphWebsite,
+    ReferrerPolicy,
+    Robots,
+    Script,
+    Stylesheet,
+    ThemeColor,
+    Title,
+    TwitterCard,
+    Verification,
+)
+from pyhead.protocols import CompileDelayed
+
+
+class _Delayed:
+    """Minimal CompileDelayed stand-in for tests — no Flask needed."""
+
+    def __init__(self, value: str) -> None:
+        self._value = value
+
+    def compile(self) -> str:
+        return self._value
+
+
+def test_compile_delayed_is_isinstance():
+    assert isinstance(_Delayed("/x"), CompileDelayed)
+
+
+# ---------- Title ----------
+
+
+def test_title_basic():
+    assert str(Title("Hello")) == "<title>Hello</title>"
+
+
+def test_title_escapes_angle_brackets():
+    out = str(Title("<script>alert(1)</script>"))
+    assert "<script>" not in out
+    assert "&lt;script&gt;" in out
+
+
+# ---------- Charset ----------
+
+
+def test_charset_default():
+    assert str(Charset()) == '<meta charset="utf-8">'
+
+
+def test_charset_custom():
+    assert str(Charset("latin-1")) == '<meta charset="latin-1">'
+
+
+# ---------- Meta ----------
+
+
+def test_meta_name_content():
+    assert str(Meta(name="foo", content="bar")) == '<meta name="foo" content="bar">'
+
+
+def test_meta_http_equiv():
+    assert (
+        str(Meta(http_equiv="refresh", content="30"))
+        == '<meta http-equiv="refresh" content="30">'
+    )
+
+
+def test_meta_property():
+    assert (
+        str(Meta(property_="og:type", content="website"))
+        == '<meta property="og:type" content="website">'
+    )
+
+
+def test_meta_escapes_quotes_in_content():
+    out = str(Meta(name="desc", content='a"b'))
+    assert '"a"b"' not in out
+    assert "&#34;" in out
+
+
+def test_meta_requires_one_of_name_http_equiv_property():
+    with pytest.raises(ValueError, match="requires exactly one"):
+        Meta(content="x")
+
+
+def test_meta_rejects_multiple_of_name_http_equiv_property():
+    with pytest.raises(ValueError, match="not multiple"):
+        Meta(name="a", http_equiv="b", content="x")
+
+
+def test_meta_compile_delayed_content():
+    out = str(Meta(name="url", content=_Delayed("/page")))
+    assert 'content="/page"' in out
+
+
+def test_meta_escapes_compile_delayed_output():
+    out = str(Meta(name="url", content=_Delayed("a&b")))
+    assert "a&amp;b" in out
+
+
+# ---------- Description / Keywords ----------
+
+
+def test_description():
+    assert (
+        str(Description("hello world"))
+        == '<meta name="description" content="hello world">'
+    )
+
+
+def test_description_escapes():
+    assert "&#34;" in str(Description('say "hi"'))
+
+
+def test_keywords_from_list():
+    assert (
+        str(Keywords(from_list=["a", "b"])) == '<meta name="keywords" content="a, b">'
+    )
+
+
+def test_keywords_from_string():
+    assert str(Keywords(from_string="a,b")) == '<meta name="keywords" content="a, b">'
+
+
+def test_keywords_escapes():
+    assert "&lt;x&gt;" in str(Keywords(from_list=["<x>"]))
+
+
+# ---------- Link ----------
+
+
+def test_link_minimal():
+    assert str(Link(rel="canonical", href="/")) == '<link rel="canonical" href="/">'
+
+
+def test_link_with_all_attrs():
+    out = str(
+        Link(
+            rel="preload",
+            href="/f.woff2",
+            type_="font/woff2",
+            crossorigin="anonymous",
+            id_="font-1",
+        )
+    )
+    assert 'rel="preload"' in out
+    assert 'href="/f.woff2"' in out
+    assert 'type="font/woff2"' in out
+    assert 'crossorigin="anonymous"' in out
+    assert 'id="font-1"' in out
+
+
+def test_link_escapes_href():
+    out = str(Link(rel="canonical", href="/?a=1&b=2"))
+    assert "&amp;" in out
+
+
+def test_link_compile_delayed_href():
+    assert (
+        str(Link(rel="stylesheet", href=_Delayed("/s.css")))
+        == '<link rel="stylesheet" href="/s.css">'
+    )
+
+
+# ---------- Script ----------
+
+
+def test_script_minimal():
+    assert str(Script(src="/a.js")) == '<script src="/a.js"></script>'
+
+
+def test_script_type_module_async():
+    out = str(Script(src="/a.js", type_="module", async_=True))
+    assert 'type="module"' in out
+    assert 'async="true"' in out
+
+
+def test_script_compile_delayed_src():
+    assert str(Script(src=_Delayed("/a.js"))) == '<script src="/a.js"></script>'
+
+
+def test_script_escapes_src():
+    assert "&amp;" in str(Script(src="/a.js?x=1&y=2"))
+
+
+# ---------- Base / Stylesheet / ApplicationName / CSP / ThemeColor / ReferrerPolicy / Robots ----------
+
+
+def test_base():
+    assert str(Base("https://example.com/")) == '<base href="https://example.com/">'
+
+
+def test_base_compile_delayed():
+    assert str(Base(_Delayed("/"))) == '<base href="/">'
+
+
+def test_stylesheet_minimal():
+    assert str(Stylesheet("/app.css")) == '<link rel="stylesheet" href="/app.css">'
+
+
+def test_stylesheet_with_id():
+    assert (
+        str(Stylesheet("/app.css", id_="main"))
+        == '<link rel="stylesheet" href="/app.css" id="main">'
+    )
+
+
+def test_application_name():
+    assert (
+        str(ApplicationName("MyApp"))
+        == '<meta name="application_name" content="MyApp">'
+    )
+
+
+def test_content_security_policy_default():
+    out = str(ContentSecurityPolicy())
+    assert 'http-equiv="Content-Security-Policy"' in out
+    assert "default-src &#39;self&#39;" in out
+
+
+def test_theme_color():
+    assert str(ThemeColor("#ff0000")) == '<meta name="theme-color" content="#ff0000">'
+
+
+def test_referrer_policy():
+    assert (
+        str(ReferrerPolicy("no-referrer"))
+        == '<meta name="referrer" content="no-referrer">'
+    )
+
+
+def test_robots():
+    assert (
+        str(Robots("index, follow")) == '<meta name="robots" content="index, follow">'
+    )
+
+
+# ---------- Google ----------
+
+
+def test_google_no_sitelinks_search_box_is_emitted():
+    out = str(Google(no_sitelinks_search_box=True))
+    assert 'content="nositelinkssearchbox"' in out
+
+
+def test_google_combined():
+    out = str(
+        Google(
+            googlebot="index, follow",
+            no_sitelinks_search_box=True,
+            no_translate=True,
+        )
+    )
+    assert 'name="googlebot"' in out
+    assert "nositelinkssearchbox" in out
+    assert "notranslate" in out
+
+
+# ---------- GeoPosition ----------
+
+
+def test_geo_position_icbm():
+    out = str(GeoPosition(icbm="1,2"))
+    assert 'name="ICBM"' in out
+
+
+def test_geo_position_all():
+    out = str(
+        GeoPosition(
+            icbm="1,2",
+            geo_position="1;2",
+            geo_region="en_GB",
+            geo_placename="Somewhere",
+        )
+    )
+    for needle in ["ICBM", "geo.position", "geo.region", "geo.placename"]:
+        assert needle in out
+
+
+# ---------- FormatDetection ----------
+
+
+def test_format_detection_default_empty():
+    assert str(FormatDetection()) == ""
+
+
+def test_format_detection_disabled():
+    out = str(FormatDetection(telephone=False, email=False))
+    assert 'content="telephone=no,email=no"' in out
+
+
+# ---------- Verification ----------
+
+
+def test_verification_google():
+    out = str(Verification(google="abc"))
+    assert 'name="google-site-verification"' in out
+    assert 'content="abc"' in out
+
+
+def test_verification_no_alexa_param():
+    with pytest.raises(TypeError):
+        Verification(alexa="x")  # type: ignore[call-arg]
+
+
+# ---------- TwitterCard / OpenGraphWebsite ----------
+
+
+def test_twitter_card_default():
+    out = str(TwitterCard(title="T"))
+    assert 'name="twitter:card" content="summary"' in out
+    assert 'name="twitter:title" content="T"' in out
+
+
+def test_open_graph_website():
+    out = str(OpenGraphWebsite(title="T", url="/", site_name="S"))
+    assert 'property="og:type" content="website"' in out
+    assert 'property="og:title"' in out
+    assert 'property="og:url"' in out
+    assert 'property="og:site_name"' in out
+
+
+# ---------- Favicon ----------
+
+
+def test_favicon_repr_does_not_crash():
+    f = Favicon(ico_icon_href="/f.ico", png_mstile_70_href="/m.png")
+    assert "Favicon(" in repr(f)
+
+
+def test_favicon_mstile_emits_type_attribute():
+    out = str(Favicon(png_mstile_70_href="/m.png"))
+    assert 'type="image/png"' in out
+
+
+# ---------- Markup return type ----------
+
+
+def test_str_returns_markup():
+    assert isinstance(str.__call__(Title("x")), str)
+    assert isinstance(Title("x").__str__(), Markup)
+
+
+def test_call_returns_markup():
+    assert isinstance(Title("x")(), Markup)

--- a/tests/test_head.py
+++ b/tests/test_head.py
@@ -39,7 +39,7 @@ def test_head_compile_is_markup():
 
 def test_head_title_attr_is_set():
     h = Head([Page(title="My Title")])
-    assert h.title == "My Title"
+    assert h.render_title_tag == "My Title"
 
 
 def test_head_skip_title():

--- a/tests/test_head.py
+++ b/tests/test_head.py
@@ -1,0 +1,146 @@
+import pytest
+from markupsafe import Markup
+
+from pyhead import Head, HeadClass
+from pyhead.elements import Description, Page, Script, Stylesheet, Title
+
+
+# ---------- Head basic wiring ----------
+
+
+def test_head_page_compiles_all_fields():
+    out = str(
+        Head(
+            [
+                Page(
+                    title="T",
+                    description="D",
+                    keywords="a, b",
+                    subject="S",
+                    rating="General",
+                )
+            ]
+        ).compile()
+    )
+    for needle in [
+        '<meta charset="utf-8">',
+        "<title>T</title>",
+        'name="description" content="D"',
+        'name="keywords" content="a,  b"',
+        'name="subject" content="S"',
+        'name="rating" content="General"',
+    ]:
+        assert needle in out
+
+
+def test_head_compile_is_markup():
+    assert isinstance(Head([Page(title="T")]).compile(), Markup)
+
+
+def test_head_title_attr_is_set():
+    h = Head([Page(title="My Title")])
+    assert h.title == "My Title"
+
+
+def test_head_skip_title():
+    h = Head([Page(title="T")])
+    out = str(h.compile(skip_title=True))
+    assert "<title>T</title>" not in out
+    assert "charset" in out
+
+
+# ---------- Charset before title ordering ----------
+
+
+def test_head_emits_charset_before_title():
+    out = str(Head([Page(title="T")]).compile())
+    charset_idx = out.index('<meta charset="utf-8">')
+    title_idx = out.index("<title>T</title>")
+    assert charset_idx < title_idx
+
+
+# ---------- extend ----------
+
+
+def test_extend_preserves_existing_scripts():
+    h = Head([Script("a.js"), Script("b.js")])
+    h.extend([Script("c.js")])
+    out = str(h.compile())
+    assert "a.js" in out
+    assert "b.js" in out
+    assert "c.js" in out
+
+
+def test_extend_updates_tracked_elements_for_copy():
+    h = Head([Page(title="Orig")])
+    h.extend([Description("Added")])
+    out = str(h.copy().compile())
+    assert "Added" in out
+    assert "<title>Orig</title>" in out
+
+
+# ---------- copy is deep ----------
+
+
+def test_copy_is_deep():
+    h1 = Head([Description("orig")])
+    h2 = h1.copy()
+    h1.e["description"]._description = "mutated"
+    assert "orig" in str(h2.compile())
+    assert "mutated" not in str(h2.compile())
+
+
+def test_copy_and_extend_does_not_mutate_original():
+    h1 = Head([Page(title="Original")])
+    h2 = h1.copy().extend([Description("Only on h2")])
+    assert "Only on h2" not in str(h1.compile())
+    assert "Only on h2" in str(h2.compile())
+
+
+# ---------- Page replaces earlier Page fields ----------
+
+
+def test_second_page_overwrites_first():
+    out = str(Head([Page(title="First"), Page(title="Second")]).compile())
+    assert "<title>Second</title>" in out
+    assert "<title>First</title>" not in out
+
+
+# ---------- HeadClass ----------
+
+
+def test_headclass_direct_instantiation_raises():
+    with pytest.raises(TypeError, match="subclassed"):
+        HeadClass()
+
+
+def test_headclass_subclass_without_elements_raises():
+    class _NoElems(HeadClass):
+        pass
+
+    with pytest.raises(TypeError, match="elements"):
+        _NoElems()
+
+
+def test_headclass_subclass_returns_head_instance():
+    class _MyHead(HeadClass):
+        elements = [Title("Sub")]
+
+    instance = _MyHead()
+    assert isinstance(instance, Head)
+    assert "<title>Sub</title>" in str(instance.compile())
+
+
+# ---------- Keyed vs index-fallback keying ----------
+
+
+def test_explicit_id_wins_over_fallback():
+    h = Head([Script("a.js"), Script("b.js", id_="mine")])
+    assert "mine" in h.e
+    assert "0" in h.e
+    assert "1" not in h.e
+
+
+def test_stylesheet_id_is_rendered():
+    out = str(Stylesheet("/s.css", id_="main"))
+    assert 'id="main"' in out

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,21 @@
 version = 1
 requires-python = ">=3.10"
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version < '3.12'",
+]
+
+[[package]]
+name = "asgiref"
+version = "3.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133", size = 24345 },
+]
 
 [[package]]
 name = "blinker"
@@ -120,12 +136,58 @@ wheels = [
 ]
 
 [[package]]
+name = "django"
+version = "5.2.13"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12'",
+]
+dependencies = [
+    { name = "asgiref", marker = "python_full_version < '3.12'" },
+    { name = "sqlparse", marker = "python_full_version < '3.12'" },
+    { name = "tzdata", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/c5/c69e338eb2959f641045802e5ea87ca4bf5ac90c5fd08953ca10742fad51/django-5.2.13.tar.gz", hash = "sha256:a31589db5188d074c63f0945c3888fad104627dfcc236fb2b97f71f89da33bc4", size = 10890368 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/b1/51ab36b2eefcf8cdb9338c7188668a157e29e30306bfc98a379704c9e10d/django-5.2.13-py3-none-any.whl", hash = "sha256:5788fce61da23788a8ce6f02583765ab060d396720924789f97fa42119d37f7a", size = 8310982 },
+]
+
+[[package]]
+name = "django"
+version = "6.0.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+]
+dependencies = [
+    { name = "asgiref", marker = "python_full_version >= '3.12'" },
+    { name = "sqlparse", marker = "python_full_version >= '3.12'" },
+    { name = "tzdata", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/b9/4155091ad1788b38563bd77a7258c0834e8c12a7f56f6975deaf54f8b61d/django-6.0.4.tar.gz", hash = "sha256:8cfa2572b3f2768b2e84983cf3c4811877a01edb64e817986ec5d60751c113ac", size = 10907407 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/47/3d61d611609764aa71a37f7037b870e7bfb22937366974c4fd46cada7bab/django-6.0.4-py3-none-any.whl", hash = "sha256:14359c809fc16e8f81fd2b59d7d348e4d2d799da6840b10522b6edf7b8afc1da", size = 8368342 },
+]
+
+[[package]]
 name = "docutils"
 version = "0.20.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1f/53/a5da4f2c5739cf66290fac1431ee52aff6851c7c8ffd8264f13affd7bcdd/docutils-0.20.1.tar.gz", hash = "sha256:f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b", size = 2058365 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/26/87/f238c0670b94533ac0353a4e2a1a771a0cc73277b88bff23d3ae35a256c1/docutils-0.20.1-py3-none-any.whl", hash = "sha256:96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6", size = 572666 },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740 },
 ]
 
 [[package]]
@@ -194,6 +256,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442 },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484 },
 ]
 
 [[package]]
@@ -298,12 +369,30 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831 },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/31/28/e40d24d2e2eb23135f8533ad33d582359c7825623b1e022f9d460def7c05/platformdirs-4.0.0.tar.gz", hash = "sha256:cb633b2bcf10c51af60beb0ab06d2f1d69064b43abf4c185ca6b28865f3f9731", size = 19914 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/16/70be3b725073035aa5fc3229321d06e22e73e3e09f6af78dcfdf16c7636c/platformdirs-4.0.0-py3-none-any.whl", hash = "sha256:118c954d7e949b35437270383a3f2531e99dd93cf7ce4dc8340d3356d30f173b", size = 17562 },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538 },
 ]
 
 [[package]]
@@ -323,6 +412,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151 },
+]
+
+[[package]]
 name = "pyhead"
 version = "5.3.1"
 source = { editable = "." }
@@ -331,29 +429,47 @@ dependencies = [
     { name = "markupsafe" },
 ]
 
+[package.optional-dependencies]
+django = [
+    { name = "django", version = "5.2.13", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "django", version = "6.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+flask = [
+    { name = "flask" },
+]
+
 [package.dev-dependencies]
 dev = [
+    { name = "django", version = "5.2.13", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "django", version = "6.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "flask" },
     { name = "flit" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-django" },
     { name = "ruff" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.1.7" },
+    { name = "django", marker = "extra == 'django'", specifier = ">=4.2" },
+    { name = "flask", marker = "extra == 'flask'", specifier = ">=3.0" },
     { name = "markupsafe", specifier = ">=2.1.3" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "django", specifier = ">=4.2" },
     { name = "flask", specifier = "==3.1.3" },
     { name = "flit", specifier = ">=3.9.0" },
     { name = "mypy", specifier = ">=1.4.1" },
     { name = "pre-commit", specifier = ">=2.21.0" },
     { name = "pyright", specifier = ">=1.1.403" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-django", specifier = ">=4.8" },
     { name = "ruff", specifier = ">=0.12.4" },
 ]
 
@@ -368,6 +484,36 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fe/f6/35f885264ff08c960b23d1542038d8da86971c5d8c955cfab195a4f672d7/pyright-1.1.403.tar.gz", hash = "sha256:3ab69b9f41c67fb5bbb4d7a36243256f0d549ed3608678d381d5f51863921104", size = 3913526 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/b6/b04e5c2f41a5ccad74a1a4759da41adb20b4bc9d59a5e08d29ba60084d07/pyright-1.1.403-py3-none-any.whl", hash = "sha256:c0eeca5aa76cbef3fcc271259bbd785753c7ad7bcac99a9162b4c4c7daed23b3", size = 5684504 },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249 },
+]
+
+[[package]]
+name = "pytest-django"
+version = "4.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/2b/db9a193df89e5660137f5428063bcc2ced7ad790003b26974adf5c5ceb3b/pytest_django-4.12.0.tar.gz", hash = "sha256:df94ec819a83c8979c8f6de13d9cdfbe76e8c21d39473cfe2b40c9fc9be3c758", size = 91156 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/a5/41d091f697c09609e7ef1d5d61925494e0454ebf51de7de05f0f0a728f1d/pytest_django-4.12.0-py3-none-any.whl", hash = "sha256:3ff300c49f8350ba2953b90297d23bf5f589db69545f56f1ec5f8cff5da83e85", size = 26123 },
 ]
 
 [[package]]
@@ -442,6 +588,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlparse"
+version = "0.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138 },
+]
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -466,6 +621,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3c/8b/0111dd7d6c1478bf83baa1cab85c686426c7a6274119aceb2bd9d35395ad/typing_extensions-4.7.1.tar.gz", hash = "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2", size = 72876 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/6b/63cc3df74987c36fe26157ee12e09e8f9db4de771e0f3404263117e75b95/typing_extensions-4.7.1-py3-none-any.whl", hash = "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36", size = 33232 },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/f5/cd531b2d15a671a40c0f66cf06bc3570a12cd56eef98960068ebbad1bf5a/tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98", size = 197639 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9", size = 348952 },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces Django integration to the `pyhead` library, improves documentation for both Flask and Django usage, and refines the core API for more flexible rendering and extension. The most important changes are grouped below.

**Django Integration and Documentation:**

* Added Django support with new helpers `DjangoUrlFor` and `DjangoStatic` for deferred URL and static file resolution, along with template tags for rendering the `<head>` and `<title>` in Django templates. Comprehensive usage examples and installation instructions for Django are now included in the `README.md`. [[1]](diffhunk://#diff-42f3ef6ac43fc928119658ac7c7a13a4382665d601cf9d93041fe4a720143df3R1-R91) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R236-R311) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R448-R498)

**API and Core Improvements:**

* Refactored the `Head` class to support more granular rendering: you can now separately control whether the `<head>` and `<title>` tags are rendered using the `render_head_tag` and `render_title_tag` parameters in `compile()`. The class now also implements `__str__` and `__html__` for easier integration with templating engines. [[1]](diffhunk://#diff-e2a8b3d11e1112c389b3dc77e723e8c76d77bc59dc7026dc94f7058595745e63L64-R64) [[2]](diffhunk://#diff-e2a8b3d11e1112c389b3dc77e723e8c76d77bc59dc7026dc94f7058595745e63L179-R299)
* Added new methods to the `Head` class: `copy_extend`, `cp` (shortcut for `copy`), and `cpe` (shortcut for `copy_extend`), allowing easier copying and extension of head configurations.

**Codebase Cleanup and Enhancements:**

* Introduced a new `BaseElement` class in `src/pyhead/_base.py` to standardize element rendering and deduplication, removing the now-unnecessary `has_key` helper. [[1]](diffhunk://#diff-4d41315e7120b02083618c7a12fcfec4aa4c59fcef43d3635ee00055b0d7dfc6R1-R28) [[2]](diffhunk://#diff-faf0e898715a72db26ec000bf987fb4b7a1d52b147a5e52aa36626b5549bc633L1-L6) [[3]](diffhunk://#diff-e2a8b3d11e1112c389b3dc77e723e8c76d77bc59dc7026dc94f7058595745e63L131-R131)
* Updated optional dependencies in `pyproject.toml` to support `flask` and `django` extras, and improved the development dependency list.

**Documentation and Examples:**

* Expanded the `README.md` with detailed installation instructions for both Flask and Django, added new sections for Django-specific usage, and clarified head rendering options and template integration for both frameworks. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L8-R30) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L116-L172) [[3]](diffhunk://#diff-86bc68d58193da0271dbde62c9ca994ad8cd6e3f833d2a9b6aff6ff00231d57dL4-R5)

**Minor Cleanups:**

* Removed the obsolete `alexa` meta tag from example code and updated favicon link output to include the `type` attribute for consistency. [[1]](diffhunk://#diff-9cec7b11237bc29d77a439e81c9b7acfac003d8e8855731eb6bc130b5a8ce602L29) [[2]](diffhunk://#diff-9cec7b11237bc29d77a439e81c9b7acfac003d8e8855731eb6bc130b5a8ce602L101) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L63) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L210-R225)

These changes make `pyhead` more flexible and easier to use in both Flask and Django projects, while also simplifying the internal codebase and improving documentation for end users.